### PR TITLE
Add per-backend Ceph secrets

### DIFF
--- a/ansible/roles/cinder/templates/cinder.conf.j2
+++ b/ansible/roles/cinder/templates/cinder.conf.j2
@@ -159,7 +159,7 @@ rados_connect_timeout = 5
 rbd_user = {{ backend.user }}
 rbd_cluster_name = {{ backend.cluster }}
 rbd_keyring_conf = /etc/ceph/{{ backend.cluster }}.client.{{ backend.user }}.keyring
-rbd_secret_uuid = {{ cinder_rbd_secret_uuid }}
+rbd_secret_uuid = {{ ceph_backend_secrets[backend.name].uuid }}
 report_discard_supported = true
 {% if backend.availability_zone is defined %}
 backend_availability_zone = {{ backend.availability_zone }}

--- a/ansible/roles/nova-cell/defaults/main.yml
+++ b/ansible/roles/nova-cell/defaults/main.yml
@@ -88,6 +88,7 @@ nova_cell_config_validation:
 nova_hw_disk_discard: "unmap"
 
 nova_cell_ceph_backend:
+  name: "{{ cinder_backend_ceph_name }}"
   cluster: "{{ ceph_cluster }}"
   vms:
     user: "{{ ceph_nova_user }}"

--- a/ansible/roles/nova-cell/tasks/external_ceph.yml
+++ b/ansible/roles/nova-cell/tasks/external_ceph.yml
@@ -146,23 +146,15 @@
         service: "{{ nova_cell_services['nova-libvirt'] }}"
       template:
         src: "secret.xml.j2"
-        dest: "{{ libvirt_secrets_dir }}/{{ item.uuid }}.xml"
+        dest: "{{ libvirt_secrets_dir }}/{{ item.value.uuid }}.xml"
         owner: "{{ config_owner_user }}"
         group: "{{ config_owner_group }}"
         mode: "0600"
       become: true
       when:
         - service | service_enabled_and_mapped_to_host
-        - item.enabled | bool
-      with_items:
-        - uuid: "{{ rbd_secret_uuid }}"
-          name: "ceph-ephemeral-nova"
-          desc: "Ceph Client Secret for Ephemeral Storage (Nova)"
-          enabled: "{{ nova_backend == 'rbd' }}"
-        - uuid: "{{ cinder_rbd_secret_uuid }}"
-          name: "ceph-persistent-cinder"
-          desc: "Ceph Client Secret for Persistent Storage (Cinder)"
-          enabled: "{{ cinder_backend_ceph }}"
+        - nova_backend == 'rbd' or cinder_backend_ceph | bool
+      loop: "{{ ceph_backend_secrets | default({}) | dict2items }}"
       notify: "{{ libvirt_restart_handlers }}"
 
     - name: Pushing secrets key for libvirt
@@ -170,24 +162,16 @@
         service: "{{ nova_cell_services['nova-libvirt'] }}"
       template:
         src: "libvirt-secret.j2"
-        dest: "{{ libvirt_secrets_dir }}/{{ item.uuid }}.base64"
+        dest: "{{ libvirt_secrets_dir }}/{{ item.value.uuid }}.base64"
         owner: "{{ config_owner_user }}"
         group: "{{ config_owner_group }}"
         mode: "0600"
       become: true
       when:
         - service | service_enabled_and_mapped_to_host
-        - item.enabled | bool
         - external_ceph_cephx_enabled | bool
-      with_items:
-        # NOTE(yoctozepto): 'default' filter required due to eager evaluation of item content
-        # which will be undefined if the applicable condition is False
-        - uuid: "{{ rbd_secret_uuid }}"
-          result: "{{ nova_cephx_raw_key | default }}"
-          enabled: "{{ nova_backend == 'rbd' }}"
-        - uuid: "{{ cinder_rbd_secret_uuid }}"
-          result: "{{ cinder_cephx_raw_key | default }}"
-          enabled: "{{ cinder_backend_ceph }}"
+        - nova_backend == 'rbd' or cinder_backend_ceph | bool
+      loop: "{{ ceph_backend_secrets | default({}) | dict2items }}"
       notify: "{{ libvirt_restart_handlers }}"
       no_log: True
   vars:

--- a/ansible/roles/nova-cell/templates/libvirt-secret.j2
+++ b/ansible/roles/nova-cell/templates/libvirt-secret.j2
@@ -1,1 +1,1 @@
-{{ item.result }}
+{{ item.value.secret }}

--- a/ansible/roles/nova-cell/templates/nova.conf.d/libvirt.conf.j2
+++ b/ansible/roles/nova-cell/templates/nova.conf.d/libvirt.conf.j2
@@ -18,7 +18,7 @@ hw_disk_discard = {{ nova_hw_disk_discard }}
 {% endif %}
 {% endif %}
 {% if nova_backend == "rbd" and external_ceph_cephx_enabled | bool %}
-rbd_secret_uuid = {{ rbd_secret_uuid }}
+rbd_secret_uuid = {{ ceph_backend_secrets[nova_cell_ceph_backend['name']].uuid }}
 {% endif %}
 virt_type = {{ nova_compute_virt_type }}
 {% if nova_libvirt_cpu_mode %}

--- a/ansible/roles/nova-cell/templates/secret.xml.j2
+++ b/ansible/roles/nova-cell/templates/secret.xml.j2
@@ -1,7 +1,7 @@
 <secret ephemeral='no' private='no'>
-  <uuid>{{ item.uuid }}</uuid>
-  <description>{{ item.desc }}</description>
+  <uuid>{{ item.value.uuid }}</uuid>
+  <description>Ceph Client Secret for backend {{ item.key }}</description>
   <usage type='ceph'>
-    <name>{{ item.name }}</name>
+    <name>ceph-{{ item.key }}</name>
   </usage>
 </secret>

--- a/doc/source/reference/storage/external-ceph-guide.rst
+++ b/doc/source/reference/storage/external-ceph-guide.rst
@@ -282,6 +282,18 @@ the use with availability zones:
   * ``/etc/kolla/config/cinder/cinder-backup/ceph2.client.cinder.keyring``
   * ``/etc/kolla/config/cinder/cinder-backup/ceph2.client.cinder-backup.keyring``
 
+* Configure libvirt secrets for each backend in ``/etc/kolla/passwords.yml``:
+
+  .. code-block:: yaml
+
+     ceph_backend_secrets:
+       ceph1-rbd:
+         uuid: "<uuid>"
+         secret: "<base64>"
+       ceph2-rbd:
+         uuid: "<uuid>"
+         secret: "<base64>"
+
 .. note::
 
    ``cinder-backup`` requires keyrings for accessing volumes

--- a/etc/kolla/passwords.yml
+++ b/etc/kolla/passwords.yml
@@ -8,6 +8,10 @@
 # cinder_rbd_secret_uuid is used for cinder
 rbd_secret_uuid:
 cinder_rbd_secret_uuid:
+ceph_backend_secrets:
+  # backend_name:
+  #   uuid:
+  #   secret:
 
 ###################
 # Database options


### PR DESCRIPTION
## Summary
- introduce `ceph_backend_secrets` mapping
- reference backend secret UUIDs in Cinder and Nova
- manage libvirt secrets for all backends
- document backend secret configuration

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868e2f7e3e48327a4d25631c1076f53