### PR TITLE
Add per-backend Ceph secrets

### DIFF
--- a/ansible/roles/cinder/templates/cinder.conf.j2
+++ b/ansible/roles/cinder/templates/cinder.conf.j2
@@ -159,7 +159,7 @@ rados_connect_timeout = 5
 rbd_user = {{ backend.user }}
 rbd_cluster_name = {{ backend.cluster }}
 rbd_keyring_conf = /etc/ceph/{{ backend.cluster }}.client.{{ backend.user }}.keyring
-rbd_secret_uuid = {{ cinder_rbd_secret_uuid }}
+rbd_secret_uuid = {{ ceph_backend_secrets[backend.name].uuid }}
 report_discard_supported = true
 {% if backend.availability_zone is defined %}
 backend_availability_zone = {{ backend.availability_zone }}

--- a/ansible/roles/nova-cell/defaults/main.yml
+++ b/ansible/roles/nova-cell/defaults/main.yml
@@ -88,6 +88,7 @@ nova_cell_config_validation:
 nova_hw_disk_discard: "unmap"
 
 nova_cell_ceph_backend:
+  name: "{{ cinder_backend_ceph_name }}"
   cluster: "{{ ceph_cluster }}"
   vms:
     user: "{{ ceph_nova_user }}"

--- a/ansible/roles/nova-cell/tasks/external_ceph.yml
+++ b/ansible/roles/nova-cell/tasks/external_ceph.yml
@@ -14,88 +14,73 @@
     - nova_backend == "rbd"
     - external_ceph_cephx_enabled | bool
 
-- name: Check cinder keyring file
-  vars:
-    keyring: "{{ nova_cell_ceph_backend['cluster'] }}.client.{{ nova_cell_ceph_backend['volumes']['user'] }}.keyring"
-    paths:
-      - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ keyring }}"
-      - "{{ node_custom_config }}/nova/{{ keyring }}"
-  stat:
-    path: "{{ lookup('first_found', paths) }}"
-  delegate_to: localhost
-  register: cinder_cephx_keyring_file
-  failed_when: not cinder_cephx_keyring_file.stat.exists
-  when:
-    - cinder_backend_ceph | bool
-    - external_ceph_cephx_enabled | bool
-
-- name: Extract nova key from file
-  set_fact:
-    nova_cephx_raw_key:
-      "{{ lookup('template', nova_cephx_keyring_file.stat.path) | regex_search('key\\s*=.*$', multiline=True) | regex_replace('key\\s*=\\s*(.*)\\s*', '\\1') }}"
-  changed_when: false
-  when:
-    - nova_backend == "rbd"
-    - external_ceph_cephx_enabled | bool
-
-- name: Extract cinder key from file
-  set_fact:
-    cinder_cephx_raw_key:
-      "{{ lookup('template', cinder_cephx_keyring_file.stat.path) | regex_search('key\\s*=.*$', multiline=True) | regex_replace('key\\s*=\\s*(.*)\\s*', '\\1') }}"
-  changed_when: false
-  when:
-    - cinder_backend_ceph | bool
-    - external_ceph_cephx_enabled | bool
-
-- name: Copy over ceph nova keyring file
-  template:
-    src: "{{ nova_cephx_keyring_file.stat.path }}"
-    dest: "{{ node_config_directory }}/{{ item }}/"
-    owner: "{{ config_owner_user }}"
-    group: "{{ config_owner_group }}"
-    mode: "0660"
-  become: true
-  with_items:
-    - nova-compute
-  when:
-    - inventory_hostname in groups[nova_cell_compute_group]
-    - nova_backend == "rbd"
-    - external_ceph_cephx_enabled | bool
-
-- name: Copy over ceph cinder keyring file
-  template:
-    src: "{{ cinder_cephx_keyring_file.stat.path }}"
-    dest: "{{ node_config_directory }}/{{ item }}/"
-    owner: "{{ config_owner_user }}"
-    group: "{{ config_owner_group }}"
-    mode: "0660"
-  become: true
-  with_items:  # NOTE: nova-libvirt does not need it
-    - nova-compute
-  when:
-    - inventory_hostname in groups[nova_cell_compute_group]
-    - nova_backend == "rbd"
-    - external_ceph_cephx_enabled | bool
-
-- name: Copy over ceph.conf
+- name: Ensure nova service ceph config subdir exists
   vars:
     service: "{{ nova_cell_services[item] }}"
-    paths:
-      - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ nova_cell_ceph_backend['cluster'] }}.conf"
-      - "{{ node_custom_config }}/nova/{{ nova_cell_ceph_backend['cluster'] }}.conf"
-  template:
-    src: "{{ lookup('first_found', paths) }}"
-    dest: "{{ node_config_directory }}/{{ item }}/"
+  file:
+    path: "{{ node_config_directory }}/{{ item }}/ceph"
+    state: "directory"
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
-    mode: "0660"
+    mode: "0770"
   become: true
+  when: service | service_enabled_and_mapped_to_host
   with_items:
     - nova-compute
     - nova-libvirt
+
+
+- name: Copy over ceph nova keyring file
+  vars:
+    keyring: "{{ nova_cell_ceph_backend['cluster'] }}.client.{{ nova_cell_ceph_backend['vms']['user'] }}.keyring"
+  template:
+    src: "{{ nova_cephx_keyring_file.stat.path }}"
+    dest: "{{ node_config_directory }}/nova-compute/ceph/{{ keyring }}"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0660"
+  become: true
+  when:
+    - inventory_hostname in groups[nova_cell_compute_group]
+    - nova_backend == "rbd"
+    - external_ceph_cephx_enabled | bool
+
+- name: Copy over ceph cinder keyring files
+  vars:
+    keyring: "{{ item.1.cluster }}.client.{{ item.1.user }}.keyring"
+    service: "{{ nova_cell_services[item.0] }}"
+  template:
+    src: "{{ node_custom_config }}/nova/{{ keyring }}"
+    dest: "{{ node_config_directory }}/{{ item.0 }}/ceph/{{ keyring }}"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0660"
+  become: true
+  when:
+    - inventory_hostname in groups[nova_cell_compute_group]
+    - external_ceph_cephx_enabled | bool
+    - service | service_enabled_and_mapped_to_host
+  with_nested:
+    - [ 'nova-compute', 'nova-libvirt' ]
+    - "{{ cinder_ceph_backends }}"
+
+- name: Copy over ceph.conf
+  vars:
+    service: "{{ nova_cell_services[item.0] }}"
+    cluster: "{{ item.1.cluster }}"
+  merge_configs:
+    sources:
+      - "{{ node_custom_config }}/nova/{{ cluster }}.conf"
+      - "{{ node_custom_config }}/nova/{{ item.0 }}/{{ cluster }}.conf"
+    dest: "{{ node_config_directory }}/{{ item.0 }}/ceph/{{ cluster }}.conf"
+    mode: "0660"
+  become: true
   when:
     - service | service_enabled_and_mapped_to_host
-    - nova_backend == "rbd"
+    - nova_backend == "rbd" or cinder_backend_ceph | bool
+  with_nested:
+    - [ 'nova-compute', 'nova-libvirt' ]
+    - "{{ cinder_ceph_backends + [nova_cell_ceph_backend] }}"
 
 - block:
     - name: Ensure /etc/ceph directory exists (host libvirt)
@@ -114,15 +99,16 @@
     - name: Copy over ceph.conf (host libvirt)
       vars:
         paths:
-          - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ nova_cell_ceph_backend['cluster'] }}.conf"
-          - "{{ node_custom_config }}/nova/{{ nova_cell_ceph_backend['cluster'] }}.conf"
+          - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ item.cluster }}.conf"
+          - "{{ node_custom_config }}/nova/{{ item.cluster }}.conf"
       template:
         src: "{{ lookup('first_found', paths) }}"
-        dest: "/etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.conf"
+        dest: "/etc/ceph/{{ item.cluster }}.conf"
         owner: "root"
         group: "root"
         mode: "0644"
       become: true
+      loop: "{{ cinder_ceph_backends + [nova_cell_ceph_backend] }}"
   when:
     - not enable_nova_libvirt_container | bool
     - inventory_hostname in groups[nova_cell_compute_group]
@@ -146,23 +132,15 @@
         service: "{{ nova_cell_services['nova-libvirt'] }}"
       template:
         src: "secret.xml.j2"
-        dest: "{{ libvirt_secrets_dir }}/{{ item.uuid }}.xml"
+        dest: "{{ libvirt_secrets_dir }}/{{ item.value.uuid }}.xml"
         owner: "{{ config_owner_user }}"
         group: "{{ config_owner_group }}"
         mode: "0600"
       become: true
       when:
         - service | service_enabled_and_mapped_to_host
-        - item.enabled | bool
-      with_items:
-        - uuid: "{{ rbd_secret_uuid }}"
-          name: "ceph-ephemeral-nova"
-          desc: "Ceph Client Secret for Ephemeral Storage (Nova)"
-          enabled: "{{ nova_backend == 'rbd' }}"
-        - uuid: "{{ cinder_rbd_secret_uuid }}"
-          name: "ceph-persistent-cinder"
-          desc: "Ceph Client Secret for Persistent Storage (Cinder)"
-          enabled: "{{ cinder_backend_ceph }}"
+        - nova_backend == 'rbd' or cinder_backend_ceph | bool
+      loop: "{{ ceph_backend_secrets | default({}) | dict2items }}"
       notify: "{{ libvirt_restart_handlers }}"
 
     - name: Pushing secrets key for libvirt
@@ -170,24 +148,16 @@
         service: "{{ nova_cell_services['nova-libvirt'] }}"
       template:
         src: "libvirt-secret.j2"
-        dest: "{{ libvirt_secrets_dir }}/{{ item.uuid }}.base64"
+        dest: "{{ libvirt_secrets_dir }}/{{ item.value.uuid }}.base64"
         owner: "{{ config_owner_user }}"
         group: "{{ config_owner_group }}"
         mode: "0600"
       become: true
       when:
         - service | service_enabled_and_mapped_to_host
-        - item.enabled | bool
         - external_ceph_cephx_enabled | bool
-      with_items:
-        # NOTE(yoctozepto): 'default' filter required due to eager evaluation of item content
-        # which will be undefined if the applicable condition is False
-        - uuid: "{{ rbd_secret_uuid }}"
-          result: "{{ nova_cephx_raw_key | default }}"
-          enabled: "{{ nova_backend == 'rbd' }}"
-        - uuid: "{{ cinder_rbd_secret_uuid }}"
-          result: "{{ cinder_cephx_raw_key | default }}"
-          enabled: "{{ cinder_backend_ceph }}"
+        - nova_backend == 'rbd' or cinder_backend_ceph | bool
+      loop: "{{ ceph_backend_secrets | default({}) | dict2items }}"
       notify: "{{ libvirt_restart_handlers }}"
       no_log: True
   vars:

--- a/ansible/roles/nova-cell/templates/libvirt-secret.j2
+++ b/ansible/roles/nova-cell/templates/libvirt-secret.j2
@@ -1,1 +1,1 @@
-{{ item.result }}
+{{ item.value.secret }}

--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -12,19 +12,14 @@
             "dest": "/etc/nova/{{ nova_policy_file }}",
             "owner": "nova",
             "perm": "0600"
-        }{% endif %}{% if nova_backend == "rbd" %},
+{% if nova_backend == "rbd" or cinder_backend_ceph | bool %},
         {
-            "source": "{{ container_config_directory }}/{{ nova_cell_ceph_backend['cluster'] }}.client.{{ nova_cell_ceph_backend['vms']['user'] }}.keyring",
-            "dest": "/etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.client.{{ nova_cell_ceph_backend['vms']['user'] }}.keyring",
+            "source": "{{ container_config_directory }}/ceph",
+            "dest": "/etc/ceph",
             "owner": "nova",
-            "perm": "0600"
-        },
-        {
-            "source": "{{ container_config_directory }}/{{ nova_cell_ceph_backend['cluster'] }}.conf",
-            "dest": "/etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.conf",
-            "owner": "nova",
-            "perm": "0600"
-        }{% endif %}{% if nova_compute_virt_type == "vmware" and not vmware_vcenter_insecure | bool %},
+            "perm": "0600",
+            "merge": true
+        }{% endif %}
         {
             "source": "{{ container_config_directory }}/vmware_ca",
             "dest": "/etc/nova/vmware_ca",

--- a/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
@@ -49,13 +49,14 @@
             "owner": "root",
             "perm": "0600",
             "merge": true
-        }{% endif %}{% if nova_backend == "rbd" %},
+        },
         {
-            "source": "{{ container_config_directory }}/{{ nova_cell_ceph_backend['cluster'] }}.conf",
-            "dest": "/etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.conf",
+            "source": "{{ container_config_directory }}/ceph",
+            "dest": "/etc/ceph",
             "owner": "nova",
-            "perm": "0600"
-        }{% endif %}{% if libvirt_enable_sasl | bool %},
+            "perm": "0600",
+            "merge": true
+        }{% endif %}
         {
             "source": "{{ container_config_directory }}/sasl.conf",
             "dest": "/etc/sasl2/libvirt.conf",

--- a/ansible/roles/nova-cell/templates/nova.conf.d/libvirt.conf.j2
+++ b/ansible/roles/nova-cell/templates/nova.conf.d/libvirt.conf.j2
@@ -18,7 +18,7 @@ hw_disk_discard = {{ nova_hw_disk_discard }}
 {% endif %}
 {% endif %}
 {% if nova_backend == "rbd" and external_ceph_cephx_enabled | bool %}
-rbd_secret_uuid = {{ rbd_secret_uuid }}
+rbd_secret_uuid = {{ ceph_backend_secrets[nova_cell_ceph_backend['name']].uuid }}
 {% endif %}
 virt_type = {{ nova_compute_virt_type }}
 {% if nova_libvirt_cpu_mode %}

--- a/ansible/roles/nova-cell/templates/secret.xml.j2
+++ b/ansible/roles/nova-cell/templates/secret.xml.j2
@@ -1,7 +1,7 @@
 <secret ephemeral='no' private='no'>
-  <uuid>{{ item.uuid }}</uuid>
-  <description>{{ item.desc }}</description>
+  <uuid>{{ item.value.uuid }}</uuid>
+  <description>Ceph Client Secret for backend {{ item.key }}</description>
   <usage type='ceph'>
-    <name>{{ item.name }}</name>
+    <name>ceph-{{ item.key }}</name>
   </usage>
 </secret>

--- a/doc/source/reference/storage/external-ceph-guide.rst
+++ b/doc/source/reference/storage/external-ceph-guide.rst
@@ -282,6 +282,18 @@ the use with availability zones:
   * ``/etc/kolla/config/cinder/cinder-backup/ceph2.client.cinder.keyring``
   * ``/etc/kolla/config/cinder/cinder-backup/ceph2.client.cinder-backup.keyring``
 
+* Configure libvirt secrets for each backend in ``/etc/kolla/passwords.yml``:
+
+  .. code-block:: yaml
+
+     ceph_backend_secrets:
+       ceph1-rbd:
+         uuid: "<uuid>"
+         secret: "<base64>"
+       ceph2-rbd:
+         uuid: "<uuid>"
+         secret: "<base64>"
+
 .. note::
 
    ``cinder-backup`` requires keyrings for accessing volumes
@@ -289,10 +301,9 @@ the use with availability zones:
 
 Nova must also be configured to allow access to Cinder volumes:
 
-* Copy Ceph config and keyring file(s) to:
-
-  * ``/etc/kolla/config/nova/ceph.conf``
-  * ``/etc/kolla/config/nova/ceph.client.cinder.keyring``
+* Copy Ceph config and keyring file(s) to ``/etc/kolla/config/nova``. For
+  multiple backends provide files named ``<cluster>.conf`` and
+  ``<cluster>.client.<user>.keyring`` for each backend.
 
 To configure different Ceph backends for nova-compute hosts, which is useful
 for use with availability zones:

--- a/etc/kolla/passwords.yml
+++ b/etc/kolla/passwords.yml
@@ -8,6 +8,10 @@
 # cinder_rbd_secret_uuid is used for cinder
 rbd_secret_uuid:
 cinder_rbd_secret_uuid:
+ceph_backend_secrets:
+  # backend_name:
+  #   uuid:
+  #   secret:
 
 ###################
 # Database options


### PR DESCRIPTION
## Summary
- introduce `ceph_backend_secrets` mapping
- reference backend secret UUIDs in Cinder and Nova
- manage libvirt secrets for all backends
- document backend secret configuration
- copy configs and keyrings for every Nova backend

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868e2f7e3e48327a4d25631c1076f53