### PR TITLE
Update genpwd for per-backend Ceph secrets

### DIFF
--- a/doc/source/reference/storage/external-ceph-guide.rst
+++ b/doc/source/reference/storage/external-ceph-guide.rst
@@ -290,9 +290,12 @@ the use with availability zones:
        ceph1-rbd:
          uuid: "<uuid>"
          secret: "<base64>"
-       ceph2-rbd:
-         uuid: "<uuid>"
-         secret: "<base64>"
+      ceph2-rbd:
+        uuid: "<uuid>"
+        secret: "<base64>"
+
+  ``kolla-genpwd`` will automatically populate ``ceph_backend_secrets`` with a
+  unique UUID and secret for each backend defined.
 
 .. note::
 

--- a/kolla_ansible/cmd/genpwd.py
+++ b/kolla_ansible/cmd/genpwd.py
@@ -88,6 +88,23 @@ def genpwd(passwords_file, length, uuid_keys, ssh_keys, blank_keys,
                 'public_key': public_key
             }
             continue
+        if k == 'ceph_backend_secrets':
+            if v is None:
+                passwords[k] = {}
+            elif isinstance(v, dict):
+                for backend, secret_dict in v.items():
+                    if secret_dict is None:
+                        secret_dict = {}
+                    if secret_dict.get('uuid') is None:
+                        secret_dict['uuid'] = uuidutils.generate_uuid()
+                    if secret_dict.get('secret') is None:
+                        secret_dict['secret'] = ''.join([
+                            random.SystemRandom().choice(
+                                string.ascii_letters + string.digits)
+                            for n in range(length)
+                        ])
+                    passwords[k][backend] = secret_dict
+            continue
         if v is None:
             if k in blank_keys and v is None:
                 continue


### PR DESCRIPTION
## Summary
- generate UUID and secret for each backend under `ceph_backend_secrets`
- document automatic population of Ceph backend secrets

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686901e6e92c8327b7684316df4c6c8e