### PR TITLE
docs: describe using multiple pools in one ceph cluster

### DIFF
--- a/etc/kolla/passwords.yml
+++ b/etc/kolla/passwords.yml
@@ -12,6 +12,12 @@ ceph_backend_secrets:
   # backend_name:
   #   uuid:
   #   secret:
+  #fast-rbd:
+  #  uuid: <uuid>
+  #  secret: <base64>
+  #slow-rbd:
+  #  uuid: <uuid>
+  #  secret: <base64>
 
 ###################
 # Database options


### PR DESCRIPTION
## Summary
- update external ceph guide to cover multiple pools in a single cluster
- show example secrets structure in passwords.yml

## Testing
- `tox -e docs` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68690f66c3748327b09f2a39eee90917