### PR TITLE
Update nova-cell Ceph backend default

### DIFF
--- a/ansible/roles/nova-cell/defaults/main.yml
+++ b/ansible/roles/nova-cell/defaults/main.yml
@@ -88,7 +88,7 @@ nova_cell_config_validation:
 nova_hw_disk_discard: "unmap"
 
 nova_cell_ceph_backend:
-  name: "{{ cinder_backend_ceph_name }}"
+  name: "{{ (cinder_ceph_backends[0].name if cinder_ceph_backends|length > 0 else cinder_backend_ceph_name) }}"
   cluster: "{{ ceph_cluster }}"
   vms:
     user: "{{ ceph_nova_user }}"

--- a/doc/source/reference/storage/external-ceph-guide.rst
+++ b/doc/source/reference/storage/external-ceph-guide.rst
@@ -424,6 +424,9 @@ Configuring Nova for Ceph includes following steps:
 
   * ``ceph_nova_user`` (by default it's the same as ``ceph_cinder_user``)
   * ``ceph_nova_pool_name`` (default: ``vms``)
+  * ``nova_cell_ceph_backend.name`` defaults to the name of the first
+    backend in ``cinder_ceph_backends``. Set this to a different backend
+    when using custom Ceph pools for Nova instance disks.
 
 * For a single backend, place ``ceph.conf`` and the keyring in
   ``/etc/kolla/config/nova``. For example:


### PR DESCRIPTION
## Summary
- default `nova_cell_ceph_backend.name` to the first item in `cinder_ceph_backends`
- document the new default and how to override it

## Testing
- `tox -e docs` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68691de0000c83279b64a4be9f95f06a