### PR TITLE
Fix misplaced endif in nova-libvirt template

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
@@ -68,7 +68,7 @@
             "dest": "/root/.config/libvirt/auth.conf",
             "owner": "root",
             "perm": "0600"
-        }{% endif %}{% if kolla_copy_ca_into_containers | bool %},
+        }{% if kolla_copy_ca_into_containers | bool %},
         {
             "source": "{{ container_config_directory }}/ca-certificates",
             "dest": "/var/lib/kolla/share/ca-certificates",


### PR DESCRIPTION
## Summary
- remove stray closing tag in nova-libvirt.json.j2

## Testing
- `python3 tools/validate-all-file.py` *(fails: ModuleNotFoundError: No module named 'jinja2')*
- `ansible-playbook -i ansible/inventory/all-in-one ansible/site.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691edb84b08327890b7b7f8300645e