### PR TITLE
Fix libvirt TLS conditional comma

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
@@ -43,7 +43,7 @@
             "dest": "/etc/pki/CA/cacert.pem",
             "owner": "root",
             "perm": "0600"
-        }{% endif %},
+        },{% endif %}
 {% if nova_backend == "rbd" or cinder_backend_ceph | bool %}
         {
             "source": "{{ container_config_directory }}/secrets",


### PR DESCRIPTION
## Summary
- fix config file list in nova-libvirt.json.j2 so the comma after the TLS block is only emitted when TLS is enabled

## Testing
- `python3 /tmp/render_template.py ansible/roles/nova-cell/templates/nova-libvirt.json.j2`

------
https://chatgpt.com/codex/tasks/task_e_686923fb07088327b0065750c7695682