### PR TITLE
Wrap SASL config for nova-libvirt

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
@@ -59,6 +59,7 @@
             "perm": "0600",
             "merge": true
         },{% endif %}
+{% if libvirt_enable_sasl | bool %}
         {
             "source": "{{ container_config_directory }}/sasl.conf",
             "dest": "/etc/sasl2/libvirt.conf",
@@ -70,7 +71,7 @@
             "dest": "/root/.config/libvirt/auth.conf",
             "owner": "root",
             "perm": "0600"
-        }{% if kolla_copy_ca_into_containers | bool %},
+        }{% endif %}{% if kolla_copy_ca_into_containers | bool %},
         {
             "source": "{{ container_config_directory }}/ca-certificates",
             "dest": "/var/lib/kolla/share/ca-certificates",

--- a/releasenotes/notes/libvirt-sasl-if-block-24c786d1.yaml
+++ b/releasenotes/notes/libvirt-sasl-if-block-24c786d1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Respects ``libvirt_enable_sasl`` when rendering the ``nova_libvirt``
+    container config by omitting SASL configuration files if the feature
+    is disabled.


### PR DESCRIPTION
## Summary
- respect `libvirt_enable_sasl` when rendering nova-libvirt config
- add a release note

## Testing
- `tox` *(fails: Could not install tox due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68692623ecac8327a39d52d9e8e088d5