### PR TITLE
Fix conditional commas in nova-libvirt template

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
@@ -12,7 +12,7 @@
             "dest": "/etc/libvirt/qemu.conf",
             "owner": "root",
             "perm": "0600"
-        },
+        }{% if libvirt_tls | bool %},{% endif %}
 {% if libvirt_tls | bool %}
         {
             "source": "{{ container_config_directory }}/serverkey.pem",
@@ -43,7 +43,7 @@
             "dest": "/etc/pki/CA/cacert.pem",
             "owner": "root",
             "perm": "0600"
-        },{% endif %}
+        }{% if nova_backend == "rbd" or cinder_backend_ceph | bool or libvirt_enable_sasl | bool or kolla_copy_ca_into_containers | bool %},{% endif %}{% endif %}
 {% if nova_backend == "rbd" or cinder_backend_ceph | bool %}
         {
             "source": "{{ container_config_directory }}/secrets",
@@ -58,7 +58,7 @@
             "owner": "nova",
             "perm": "0600",
             "merge": true
-        },{% endif %}
+        }{% if libvirt_enable_sasl | bool or kolla_copy_ca_into_containers | bool %},{% endif %}{% endif %}
 {% if libvirt_enable_sasl | bool %}
         {
             "source": "{{ container_config_directory }}/sasl.conf",
@@ -71,7 +71,8 @@
             "dest": "/root/.config/libvirt/auth.conf",
             "owner": "root",
             "perm": "0600"
-        }{% endif %}{% if kolla_copy_ca_into_containers | bool %},
+        }{% if kolla_copy_ca_into_containers | bool %},{% endif %}{% endif %}
+{% if kolla_copy_ca_into_containers | bool %}
         {
             "source": "{{ container_config_directory }}/ca-certificates",
             "dest": "/var/lib/kolla/share/ca-certificates",


### PR DESCRIPTION
## Summary
- avoid trailing commas in nova-libvirt.json.j2 when optional blocks are disabled

## Testing
- `pip install tox` *(fails: Could not find a version that satisfies the requirement tox)*

------
https://chatgpt.com/codex/tasks/task_e_686929d1e6e88327806a9ce2fe42dfbd