### PR TITLE
Fix libvirt template comma logic

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
@@ -12,7 +12,9 @@
             "dest": "/etc/libvirt/qemu.conf",
             "owner": "root",
             "perm": "0600"
-        }{% if libvirt_tls | bool %},{% endif %}
+        }{% if libvirt_tls | bool or nova_backend == "rbd" or
+              cinder_backend_ceph | bool or libvirt_enable_sasl | bool or
+              kolla_copy_ca_into_containers | bool %},{% endif %}
 {% if libvirt_tls | bool %}
         {
             "source": "{{ container_config_directory }}/serverkey.pem",


### PR DESCRIPTION
## Summary
- check all optional blocks when emitting a comma after `qemu.conf`

## Testing
- `python3 tests/j2lint.py ansible/roles/nova-cell/templates/nova-libvirt.json.j2` *(fails: No module named 'ansible')*
- `python3 - <<'EOF'
try:
    import jinja2
    print('Found jinja2:', jinja2.__version__)
except Exception as e:
    print('Error:', e)
EOF` *(fails: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_68692c49da5083279a0be261160186b9