### PR TITLE
Fix nova policy conditional

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -12,20 +12,20 @@
             "dest": "/etc/nova/{{ nova_policy_file }}",
             "owner": "nova",
             "perm": "0600"
-{% if nova_backend == "rbd" or cinder_backend_ceph | bool %},
+        },{% endif %}{% if nova_backend == "rbd" or cinder_backend_ceph | bool %}
         {
             "source": "{{ container_config_directory }}/ceph",
             "dest": "/etc/ceph",
             "owner": "nova",
             "perm": "0600",
             "merge": true
-        }{% endif %}
+        },{% endif %}
         {
             "source": "{{ container_config_directory }}/vmware_ca",
             "dest": "/etc/nova/vmware_ca",
             "owner": "nova",
             "perm": "0600"
-        }{% endif %}{% if libvirt_tls | bool %},
+        }{% if libvirt_tls | bool %},
         {
             "source": "{{ container_config_directory }}/clientkey.pem",
             "dest": "/etc/pki/libvirt/private/clientkey.pem",


### PR DESCRIPTION
## Summary
- fix nova-compute.json.j2 to close the nova_policy_file conditional earlier
- add standalone ceph copy block

## Testing
- `tox` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686945165db88327bbb81fcb733021f7