### PR TITLE
Fix nova compute template JSON commas

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-compute-ironic.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute-ironic.json.j2
@@ -6,25 +6,31 @@
             "dest": "/etc/nova/nova.conf",
             "owner": "nova",
             "perm": "0600"
-        }{% if nova_policy_file is defined %},
+        },
+        {% if nova_policy_file is defined %}
         {
             "source": "{{ container_config_directory }}/{{ nova_policy_file }}",
             "dest": "/etc/nova/{{ nova_policy_file }}",
             "owner": "nova",
             "perm": "0600"
-        }{% endif %}{% if vendordata_file_path is defined %},
+        },
+        {% endif %}
+        {% if vendordata_file_path is defined %}
         {
             "source": "{{ container_config_directory }}/vendordata.json",
             "dest": "/etc/nova/vendordata.json",
             "owner": "nova",
             "perm": "0600"
-        }{% endif %}{% if kolla_copy_ca_into_containers | bool %},
+        }{% if kolla_copy_ca_into_containers | bool %},{% endif %}
+        {% endif %}
+        {% if kolla_copy_ca_into_containers | bool %}
         {
             "source": "{{ container_config_directory }}/ca-certificates",
             "dest": "/var/lib/kolla/share/ca-certificates",
             "owner": "root",
             "perm": "0600"
-        }{% endif %}
+        }
+        {% endif %}
     ],
     "permissions": [
         {

--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -6,20 +6,24 @@
             "dest": "/etc/nova/nova.conf",
             "owner": "nova",
             "perm": "0600"
-        }{% if nova_policy_file is defined %},
+        },
+        {% if nova_policy_file is defined %}
         {
             "source": "{{ container_config_directory }}/{{ nova_policy_file }}",
             "dest": "/etc/nova/{{ nova_policy_file }}",
             "owner": "nova",
             "perm": "0600"
-        },{% endif %}{% if nova_backend == "rbd" or cinder_backend_ceph | bool %}
+        },
+        {% endif %}
+        {% if nova_backend == "rbd" or cinder_backend_ceph | bool %}
         {
             "source": "{{ container_config_directory }}/ceph",
             "dest": "/etc/ceph",
             "owner": "nova",
             "perm": "0600",
             "merge": true
-        },{% endif %}
+        },
+        {% endif %}
         {
             "source": "{{ container_config_directory }}/vmware_ca",
             "dest": "/etc/nova/vmware_ca",


### PR DESCRIPTION
## Summary
- ensure nova-compute.json.j2 and nova-compute-ironic.json.j2 always produce valid JSON by unconditionally adding a comma after nova.conf and properly gating optional blocks

## Testing
- `tox -e j2lint` *(fails: `tox: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869571bc860832790518a8aa531b0d5