### PR TITLE
Fix vmware_ca condition in nova-compute template

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -23,13 +23,13 @@
             "perm": "0600",
             "merge": true
         },
-        {% endif %}
+        {% endif %}{% if nova_compute_virt_type == "vmware" and not vmware_vcenter_insecure | bool %},
         {
             "source": "{{ container_config_directory }}/vmware_ca",
             "dest": "/etc/nova/vmware_ca",
             "owner": "nova",
             "perm": "0600"
-        }{% if libvirt_tls | bool %},
+        }{% endif %}{% if libvirt_tls | bool %},
         {
             "source": "{{ container_config_directory }}/clientkey.pem",
             "dest": "/etc/pki/libvirt/private/clientkey.pem",


### PR DESCRIPTION
## Summary
- apply vmware_ca copy condition like ceilometer-compute

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686959bf723c8327ab96bcdd2c9dcd63