### PR TITLE
Fix nova vmware_ca config condition

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -23,13 +23,15 @@
             "perm": "0600",
             "merge": true
         },
-        {% endif %}{% if nova_compute_virt_type == "vmware" and not vmware_vcenter_insecure | bool %},
+        {% endif %}
+{% if nova_compute_virt_type == "vmware" and not vmware_vcenter_insecure | bool %}
         {
             "source": "{{ container_config_directory }}/vmware_ca",
             "dest": "/etc/nova/vmware_ca",
             "owner": "nova",
             "perm": "0600"
-        }{% endif %}{% if libvirt_tls | bool %},
+        },
+{% endif %}{% if libvirt_tls | bool %},
         {
             "source": "{{ container_config_directory }}/clientkey.pem",
             "dest": "/etc/pki/libvirt/private/clientkey.pem",


### PR DESCRIPTION
## Summary
- ensure nova compute config only writes `vmware_ca` block when required

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686945236d04832797bbb19a43ea4e4b