### PR TITLE
Fix nova-compute vmware_ca condition

### DIFF
--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -31,7 +31,7 @@
             "owner": "nova",
             "perm": "0600"
         },
-{% endif %}{% if libvirt_tls | bool %},
+{% endif %}{% if libvirt_tls | bool %}
         {
             "source": "{{ container_config_directory }}/clientkey.pem",
             "dest": "/etc/pki/libvirt/private/clientkey.pem",
@@ -49,7 +49,8 @@
             "dest": "/etc/pki/CA/cacert.pem",
             "owner": "root:nova",
             "perm": "0640"
-        }{% endif %},
+        },
+{% endif %}
         {
             "source": "{{ container_config_directory }}/release",
             "dest": "/etc/nova/release",


### PR DESCRIPTION
## Summary
- fix conditional block around vmware_ca so nova-compute config JSON is valid when libvirt TLS is enabled
- ensure trailing comma is part of the TLS block

## Testing
- `pip install tox` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686945236d04832797bbb19a43ea4e4b