### PR TITLE
Standardize environment retrieval across workers

### DIFF
--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -517,8 +517,8 @@ class PodmanWorker(ContainerWorker):
         return container
 
     def recreate_or_restart_container(self):
-        strategy = self.params.get(
-            'environment', dict()).get('KOLLA_CONFIG_STRATEGY')
+        environment = self.params.get('environment') or {}
+        strategy = environment.get('KOLLA_CONFIG_STRATEGY')
 
         container = self.get_container_info()
         if not container:


### PR DESCRIPTION
## Summary
- synchronize PodmanWorker environment handling with DockerWorker

## Testing
- `python -m pytest tests/kolla_container_tests/test_podman_worker.py::TestContainer::test_recreate_or_restart_container_not_container -q` *(fails: ModuleNotFoundError: No module named 'oslotest')*

------
https://chatgpt.com/codex/tasks/task_e_686b5d2ab72c8327b9cc1c59521ceb4e