### PR TITLE
docs: document restart behaviour

### DIFF
--- a/doc/source/user/operating-kolla.rst
+++ b/doc/source/user/operating-kolla.rst
@@ -242,6 +242,9 @@ images on hosts.
 files for enabled OpenStack services, without then restarting the containers so
 it is not applied right away.
 
+The ``COPY_ALWAYS`` ``config_strategy`` will only restart containers when
+changes are detected, avoiding unnecessary restarts.
+
 ``kolla-ansible ... -i INVENTORY1 -i INVENTORY2`` Multiple inventories can be
 specified by passing the ``--inventory`` or ``-i`` command line option multiple
 times. This can be useful to share configuration between multiple environments.


### PR DESCRIPTION
## Summary
- document default restart behaviour in operating guide

## Testing
- `tox -e docs` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b5d2805ec8327b247cf86d762c5f0