### PR TITLE
container_worker: skip compare when config_files empty

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -12,7 +12,9 @@
 
 from abc import ABC
 from abc import abstractmethod
+import json
 import logging
+import os
 import shlex
 
 from ansible.module_utils.kolla_systemd_worker import SystemdWorker
@@ -396,6 +398,21 @@ class ContainerWorker(ABC):
             # NOTE(mgoddard): Filter out any empty strings.
             tmpfs = [t for t in tmpfs if t]
         return tmpfs
+
+    def _has_config_files(self):
+        _vols, binds = self.generate_volumes()
+        if binds:
+            for src, bind in binds.items():
+                if bind.get('bind') == '/var/lib/kolla/config_files/' or \
+                        bind.get('bind').rstrip('/') == '/var/lib/kolla/config_files':
+                    config_path = os.path.join(src, 'config.json')
+                    try:
+                        with open(config_path, 'r') as f:
+                            data = json.load(f)
+                        return len(data.get('config_files', [])) > 0
+                    except Exception:
+                        return False
+        return False
 
     def generate_volumes(self, binds=None):
         if not binds:

--- a/ansible/module_utils/kolla_docker_worker.py
+++ b/ansible/module_utils/kolla_docker_worker.py
@@ -144,6 +144,8 @@ class DockerWorker(ContainerWorker):
             return True
 
     def compare_config(self):
+        if not self._has_config_files():
+            return False
         try:
             job = self.dc.exec_create(
                 self.params['name'],

--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -432,6 +432,8 @@ class PodmanWorker(ContainerWorker):
                 return True
 
     def compare_config(self):
+        if not self._has_config_files():
+            return False
         try:
             container = self.pc.containers.get(self.params['name'])
             container.reload()

--- a/ansible/roles/service-check-containers/tasks/iterated.yml
+++ b/ansible/roles/service-check-containers/tasks/iterated.yml
@@ -28,7 +28,6 @@
   when:
     - (service.enabled | default(true)) | bool
     - service.container_name is defined
-    - service.volumes | default([]) | select('search', '/var/lib/kolla/config_files') | list | length > 0
 
 # NOTE(yoctozepto): Must be a separate task because one cannot see the whole
 # result in the previous task and Ansible has a quirk regarding notifiers.

--- a/ansible/roles/service-check-containers/tasks/main.yml
+++ b/ansible/roles/service-check-containers/tasks/main.yml
@@ -29,7 +29,6 @@
     - not (service.iterate | default(False)) | bool
     - (service.enabled | default(true)) | bool
     - service.container_name is defined
-    - service.volumes | default([]) | select('search', '/var/lib/kolla/config_files') | list | length > 0
   register: container_check
 
 # NOTE(yoctozepto): Must be a separate task because one cannot see the whole

--- a/tests/kolla_container_tests/test_docker_worker.py
+++ b/tests/kolla_container_tests/test_docker_worker.py
@@ -16,8 +16,10 @@
 
 import copy
 from importlib.machinery import SourceFileLoader
+import json
 import os
 import sys
+import tempfile
 from unittest import mock
 
 from docker import errors as docker_error
@@ -943,6 +945,40 @@ class TestImage(base.BaseTestCase):
             user='root')
         self.dw.dc.exec_start.assert_called_once_with(job)
         self.dw.dc.exec_inspect.assert_called_once_with(job)
+
+    def test_compare_container_empty_config_files(self):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'config.json'), 'w') as f:
+            json.dump({'config_files': []}, f)
+        params = copy.deepcopy(FAKE_DATA['params'])
+        params['volumes'] = [f'{tmpdir}:/var/lib/kolla/config_files/:ro']
+        self.dw = get_DockerWorker(params)
+        self.dw.check_container = mock.Mock(return_value=True)
+        self.dw.check_container_differs = mock.Mock(return_value=False)
+        self.dw.systemd.check_unit_change = mock.Mock(return_value=False)
+        self.dw.dc.exec_create = mock.Mock()
+        changed = self.dw.compare_container()
+        self.assertFalse(changed)
+        self.dw.dc.exec_create.assert_not_called()
+
+    def test_compare_container_with_config_files(self):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'config.json'), 'w') as f:
+            json.dump({'config_files': [{'source': '/foo', 'dest': '/foo'}]}, f)
+        params = copy.deepcopy(FAKE_DATA['params'])
+        params['volumes'] = [f'{tmpdir}:/var/lib/kolla/config_files/:ro']
+        self.dw = get_DockerWorker(params)
+        self.dw.check_container = mock.Mock(return_value=True)
+        self.dw.check_container_differs = mock.Mock(return_value=False)
+        self.dw.systemd.check_unit_change = mock.Mock(return_value=False)
+        job = mock.MagicMock()
+        self.dw.dc.exec_create.return_value = job
+        self.dw.dc.exec_start.return_value = 'out'
+        self.dw.dc.exec_inspect.return_value = {'ExitCode': 0}
+        changed = self.dw.compare_container()
+        self.assertFalse(changed)
+        self.dw.dc.exec_create.assert_called_once_with(
+            params['name'], dwm.COMPARE_CONFIG_CMD, user='root')
 
     def test_get_image_id_not_exists(self):
         self.dw = get_DockerWorker(

--- a/tests/kolla_container_tests/test_podman_worker.py
+++ b/tests/kolla_container_tests/test_podman_worker.py
@@ -15,8 +15,10 @@
 
 import copy
 from importlib.machinery import SourceFileLoader
+import json
 import os
 import sys
+import tempfile
 import unittest
 from unittest import mock
 
@@ -828,6 +830,41 @@ class TestImage(base.BaseTestCase):
         self.assertRaises(podman_error.APIError, self.pw.compare_config)
         self.pw.pc.containers.get.assert_called_once_with(
             self.fake_data['params']['name'])
+        my_container.exec_run.assert_called_once_with(
+            pwm.COMPARE_CONFIG_CMD,
+            user='root')
+
+    def test_compare_container_empty_config_files(self):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'config.json'), 'w') as f:
+            json.dump({'config_files': []}, f)
+        params = copy.deepcopy(FAKE_DATA['params'])
+        params['volumes'] = [f'{tmpdir}:/var/lib/kolla/config_files/:ro']
+        self.pw = get_PodmanWorker(params)
+        self.pw.check_container = mock.Mock(return_value=True)
+        self.pw.check_container_differs = mock.Mock(return_value=False)
+        self.pw.systemd.check_unit_change = mock.Mock(return_value=False)
+        self.pw.pc.containers.get = mock.Mock()
+        changed = self.pw.compare_container()
+        self.assertFalse(changed)
+        self.pw.pc.containers.get.assert_not_called()
+
+    def test_compare_container_with_config_files(self):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'config.json'), 'w') as f:
+            json.dump({'config_files': [{'source': '/foo', 'dest': '/foo'}]}, f)
+        params = copy.deepcopy(FAKE_DATA['params'])
+        params['volumes'] = [f'{tmpdir}:/var/lib/kolla/config_files/:ro']
+        self.pw = get_PodmanWorker(params)
+        self.pw.check_container = mock.Mock(return_value=True)
+        self.pw.check_container_differs = mock.Mock(return_value=False)
+        self.pw.systemd.check_unit_change = mock.Mock(return_value=False)
+        my_container = construct_container(self.fake_data['containers'][0])
+        my_container.exec_run = mock.Mock(return_value=(0, b''))
+        self.pw.pc.containers.get.return_value = my_container
+        changed = self.pw.compare_container()
+        self.assertFalse(changed)
+        self.pw.pc.containers.get.assert_called_once_with(params['name'])
         my_container.exec_run.assert_called_once_with(
             pwm.COMPARE_CONFIG_CMD,
             user='root')


### PR DESCRIPTION
## Summary
- short-circuit compare_config when config.json lacks config_files
- drop redundant volume checks in service-check-containers
- add tests for docker and podman workers

## Testing
- `tox -e py39,ansible-lint,linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b7405593c8327b424d454bbc0edf4