### PR TITLE
Fix cap_add comparison

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -100,20 +100,9 @@ class ContainerWorker(ABC):
         return False
 
     def compare_cap_add(self, container_info):
-        new_cap_add = self.params.get('cap_add') or []
-        try:
-            current_cap_add = container_info['HostConfig'].get('CapAdd')
-        except (KeyError, TypeError):
-            current_cap_add = None
-
-        if not current_cap_add:
-            current_cap_add = []
-
-        if not new_cap_add and not current_cap_add:
-            return False
-
-        if sorted(new_cap_add) != sorted(current_cap_add):
-            return True
+        expected = sorted(self.params.get('cap_add') or [])
+        actual = sorted(container_info.get('HostConfig', {}).get('CapAdd') or [])
+        return expected != actual
 
     def compare_security_opt(self, container_info):
         ipc_mode = self.params.get('ipc_mode')

--- a/tests/kolla_container_tests/test_docker_worker.py
+++ b/tests/kolla_container_tests/test_docker_worker.py
@@ -1162,6 +1162,11 @@ class TestAttrComp(base.BaseTestCase):
         self.dw = get_DockerWorker({'cap_add': ['data2']})
         self.assertTrue(self.dw.compare_cap_add(container_info))
 
+    def test_compare_cap_add_none_vs_empty(self):
+        container_info = {'HostConfig': {}}
+        self.dw = get_DockerWorker({'cap_add': None})
+        self.assertFalse(self.dw.compare_cap_add(container_info))
+
     def test_compare_ipc_mode_neg(self):
         container_info = {'HostConfig': dict(IpcMode='data')}
         self.dw = get_DockerWorker({'ipc_mode': 'data'})

--- a/tests/kolla_container_tests/test_podman_worker.py
+++ b/tests/kolla_container_tests/test_podman_worker.py
@@ -1104,6 +1104,11 @@ class TestAttrComp(base.BaseTestCase):
         self.pw = get_PodmanWorker({'cap_add': ['data2']})
         self.assertTrue(self.pw.compare_cap_add(container_info))
 
+    def test_compare_cap_add_none_vs_empty(self):
+        container_info = {'HostConfig': {}}
+        self.pw = get_PodmanWorker({'cap_add': None})
+        self.assertFalse(self.pw.compare_cap_add(container_info))
+
     def test_compare_ipc_mode_neg(self):
         container_info = {'HostConfig': dict(IpcMode='data')}
         self.pw = get_PodmanWorker({'ipc_mode': 'data'})


### PR DESCRIPTION
## Summary
- fix compare_cap_add to handle None vs []
- add unit tests for the new behaviour

## Testing
- `pytest -k compare_cap_add_none_vs_empty -q` *(fails: ModuleNotFoundError: No module named 'pbr')*

------
https://chatgpt.com/codex/tasks/task_e_686d01e23aa883279761291b201d2503