### PR TITLE
Improve container diff comparisons

### DIFF
--- a/tests/test_container_worker.py
+++ b/tests/test_container_worker.py
@@ -1,0 +1,50 @@
+import pytest
+
+from ansible.module_utils.kolla_container_worker import ContainerWorker
+
+class DummyModule:
+    def __init__(self):
+        self.params = {'name': None}
+    def debug(self, msg):
+        pass
+
+class DummyWorker(ContainerWorker):
+    def __init__(self):
+        super().__init__(DummyModule())
+    def check_image(self):
+        pass
+    def get_container_info(self):
+        pass
+    def check_container(self):
+        pass
+
+@pytest.fixture
+def cw():
+    return DummyWorker()
+
+@pytest.mark.parametrize("expected,actual,diff", [
+    ([], None, False),
+    (["SYS_PTRACE"], ["SYS_PTRACE"], False),
+    (["A"], ["B"], True),
+])
+def test_compare_cap_add(expected, actual, diff, cw):
+    cw.params['cap_add'] = expected
+    container = {'HostConfig': {'CapAdd': actual}}
+    assert cw.compare_cap_add(container) is diff
+
+def test_compare_cap_add_case_duplicate(cw):
+    cw.params['cap_add'] = ["SYS_ADMIN", "NET_ADMIN"]
+    container = {
+        'HostConfig': {'CapAdd': ["NET_ADMIN", "SYS_ADMIN", "NET_ADMIN"]}
+    }
+    assert cw.compare_cap_add(container) is False
+
+def test_compare_dimensions_zero_equals_empty(cw):
+    cw.params['dimensions'] = {}
+    container = {'HostConfig': {'Resources': {'NanoCPUs': 0, 'Memory': 0}}}
+    assert cw.compare_dimensions(container) is False
+
+def test_compare_dimensions_none_vs_empty(cw):
+    cw.params['dimensions'] = {}
+    container = {'HostConfig': {'Resources': None}}
+    assert cw.compare_dimensions(container) is False


### PR DESCRIPTION
## Summary
- add list/dict normalisation helpers and use them
- fix comparisons for capabilities, tmpfs, volumes_from, security_opt and dimensions
- expand unit tests for empty and duplicate inputs

## Testing
- `python3 -m tox -e py3` *(fails: No module named tox)*
- `molecule test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d03a2d5d083279f2300734ea1ef1a