### PR TITLE
Normalize container compare helpers

### DIFF
--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -394,7 +394,7 @@ class PodmanWorker(ContainerWorker):
             return True
 
     def compare_dimensions(self, container_info):
-        new_dimensions = self.params.get('dimensions')
+        new_dimensions = _as_dict(self.params.get('dimensions'))
 
         # NOTE(mgoddard): The names used by Docker/Podman are inconsistent
         # between configuration of a container's resources and
@@ -407,8 +407,7 @@ class PodmanWorker(ContainerWorker):
             'cpuset_cpus': 'CpusetCpus', 'cpuset_mems': 'CpusetMems',
             'kernel_memory': 'KernelMemory', 'blkio_weight': 'BlkioWeight',
             'ulimits': 'Ulimits'}
-        unsupported = set(new_dimensions.keys()) - \
-            set(dimension_map.keys())
+        unsupported = set(new_dimensions.keys()) - set(dimension_map.keys())
         if unsupported:
             self.module.exit_json(
                 failed=True, msg=repr("Unsupported dimensions"),

--- a/tests/unit/test_container_compare.py
+++ b/tests/unit/test_container_compare.py
@@ -1,0 +1,107 @@
+import sys
+from unittest import mock
+
+import pytest
+
+sys.modules['dbus'] = mock.MagicMock()
+from ansible.module_utils.kolla_container_worker import ContainerWorker
+
+
+class DummyModule:
+    def __init__(self):
+        self.params = {}
+
+    def debug(self, msg):
+        pass
+
+
+class DummyWorker(ContainerWorker):
+    def __init__(self):
+        super().__init__(DummyModule())
+
+    def check_image(self):
+        return {}
+
+    def get_container_info(self):
+        pass
+
+    def check_container(self):
+        pass
+
+    def compare_pid_mode(self, container_info):
+        pass
+
+    def compare_image(self, container_info=None):
+        pass
+
+    def compare_volumes(self, container_info):
+        pass
+
+    def pull_image(self):
+        pass
+
+    def remove_container(self):
+        pass
+
+    def build_ulimits(self, ulimits):
+        pass
+
+    def create_container(self):
+        pass
+
+    def recreate_or_restart_container(self):
+        pass
+
+    def start_container(self):
+        pass
+
+    def stop_container(self):
+        pass
+
+    def stop_and_remove_container(self):
+        pass
+
+    def restart_container(self):
+        pass
+
+    def create_volume(self):
+        pass
+
+    def remove_volume(self):
+        pass
+
+    def remove_image(self):
+        pass
+
+    def ensure_image(self):
+        pass
+
+
+@pytest.fixture
+
+def worker():
+    return DummyWorker()
+
+
+@pytest.mark.parametrize("spec,current,expect_diff", [
+    (None, [], False),
+    ([], None, False),
+    ([], [], False),
+    (["SYS_PTRACE"], [], True),
+])
+def test_compare_cap_add(worker, spec, current, expect_diff):
+    worker.params['cap_add'] = spec
+    container = {'HostConfig': {'CapAdd': current}}
+    assert worker.compare_cap_add(container) is expect_diff
+
+
+@pytest.mark.parametrize("spec,current,expect_diff", [
+    (None, {}, False),
+    ({}, None, False),
+    ({}, {}, False),
+    ({'cpu_quota': 10}, {}, True),
+])
+def test_compare_dimensions(worker, spec, current, expect_diff):
+    worker.params['dimensions'] = spec
+    container = {'HostConfig': {'Resources': current}}
+    assert worker.compare_dimensions(container) is expect_diff


### PR DESCRIPTION
## Summary
- normalize None vs empty values for list/dict comparisons
- extend Podman worker to use helper
- add unit tests for compare helpers

## Testing
- `pytest -q tests/unit/test_container_compare.py` *(fails: ModuleNotFoundError: No module named 'ansible')*

------
https://chatgpt.com/codex/tasks/task_e_686d09d137a083279ed5709cd45eb656