### PR TITLE
Add _as_dict helper

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -62,10 +62,37 @@ def _as_list(value):
     return list(value)
 
 
-def _as_dict(value):
-    if value in (None, False):
+def _as_dict(value) -> dict[str, str]:
+    """Return a ``dict`` representation of ``value`` with string keys/values."""
+
+    if not value:
         return {}
-    return dict(value)
+
+    if isinstance(value, dict):
+        return {str(k).strip(): str(v).strip() for k, v in value.items()}
+
+    if isinstance(value, str):
+        items = value.split(',')
+    else:
+        items = []
+        for item in value:
+            if isinstance(item, str):
+                items.extend(item.split(','))
+            else:
+                items.append(str(item))
+
+    result = {}
+    for item in items:
+        item = str(item).strip()
+        if not item:
+            continue
+        if '=' in item:
+            k, v = item.split('=', 1)
+            result[k.strip()] = v.strip()
+        else:
+            result[item] = 'true'
+
+    return {str(k): str(v) for k, v in result.items()}
 
 
 def _empty_dimensions(d):

--- a/ansible/module_utils/kolla_docker_worker.py
+++ b/ansible/module_utils/kolla_docker_worker.py
@@ -18,6 +18,7 @@ import os
 
 from ansible.module_utils.kolla_container_worker import COMPARE_CONFIG_CMD
 from ansible.module_utils.kolla_container_worker import ContainerWorker
+from ansible.module_utils.kolla_container_worker import _as_dict
 
 
 def get_docker_client():
@@ -286,7 +287,7 @@ class DockerWorker(ContainerWorker):
             'volumes_from': self.params.get('volumes_from')
         }
 
-        dimensions = self.params.get('dimensions')
+        dimensions = _as_dict(self.params.get('dimensions'))
 
         if dimensions:
             dimensions = self.parse_dimensions(dimensions)

--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -18,6 +18,7 @@ import shlex
 
 from ansible.module_utils.kolla_container_worker import COMPARE_CONFIG_CMD
 from ansible.module_utils.kolla_container_worker import ContainerWorker
+from ansible.module_utils.kolla_container_worker import _as_dict
 
 uri = "http+unix:/run/podman/podman.sock"
 
@@ -107,7 +108,7 @@ class PodmanWorker(ContainerWorker):
                 args.update(healthcheck)
 
         # getting dimensions into separate parameters
-        dimensions = self.params.get('dimensions')
+        dimensions = _as_dict(self.params.get('dimensions'))
         if dimensions:
             dimensions = self.parse_dimensions(dimensions)
             args.update(dimensions)


### PR DESCRIPTION
## Summary
- add `_as_dict` for easier dictionary conversion
- use `_as_dict` for dimensions in Docker and Podman workers

## Testing
- `python -m flake8` *(fails: No module named flake8)*

------
https://chatgpt.com/codex/tasks/task_e_686d0e248d648327977a02970dda74c4