### PR TITLE
Handle implicit Podman capability

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -323,6 +323,14 @@ class ContainerWorker(ABC):
         cur_caps = self._as_empty_list(
             container_info.get("HostConfig", {}).get("CapAdd")
         )
+
+        # Podman automatically injects CAP_AUDIT_WRITE when running
+        # non-privileged containers.  If the playbook did not request any
+        # extra capabilities we treat that single implicit capability as
+        # equivalent to "no extra capabilities".
+        if not new_caps and cur_caps == ["CAP_AUDIT_WRITE"]:
+            cur_caps = []
+
         return sorted(new_caps) != sorted(cur_caps)
 
     def compare_security_opt(self, container_info):


### PR DESCRIPTION
## Summary
- allow CAP_AUDIT_WRITE to be ignored in compare_cap_add
- expand DummyWorker helper to accept params
- add tests for the CAP_AUDIT_WRITE case

## Testing
- `pip install tox` *(fails: Tunnel connection failed)*
- `tox -e pep8,py311` *(fails: tox not found)*
- `kolla-ansible reconfigure --limit openvswitch -vvv` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1f7e0c9c8327bf1a5f1553d73d98