### PR TITLE
Fix dimensions comparison when unset

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -476,8 +476,9 @@ class ContainerWorker(ABC):
 
     def compare_dimensions(self, container_info):
         """Return True if requested dimensions differ from the container."""
-
         new_dimensions = _as_dict(self.params.get("dimensions"))
+        if not self.params.get("dimensions"):
+            return False
         unsupported = set(new_dimensions) - set(self.dimension_map)
         if unsupported:
             self.module.exit_json(


### PR DESCRIPTION
## Summary
- avoid false restarts when `dimensions` are not provided

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pbr')*
- `tox -e py3` *(fails: tox: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d23ebcddc832784af8922e193d80e