### PR TITLE
Fix compare_dimensions for empty params

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -477,7 +477,7 @@ class ContainerWorker(ABC):
     def compare_dimensions(self, container_info):
         """Return True if requested dimensions differ from the container."""
         new_dimensions = _as_dict(self.params.get("dimensions"))
-        if not self.params.get("dimensions"):
+        if not new_dimensions:
             return False
         unsupported = set(new_dimensions) - set(self.dimension_map)
         if unsupported:
@@ -548,10 +548,8 @@ class ContainerWorker(ABC):
                 }
                 for k in diff_keys
             }
-            self._debug(f"compare_dimensions mismatch → {details}")
-
-            # One concise debug line Ansible will show at -vvv
-            self._debug(f"compare_dimensions mismatch → {mismatch}")
+            self._debug(f"compare_dimensions mismatch (full) → {mismatch}")
+            self._debug(f"compare_dimensions mismatch → {diff_keys}")
             return True
 
         return False

--- a/tests/kolla_container_tests/test_docker_worker.py
+++ b/tests/kolla_container_tests/test_docker_worker.py
@@ -1441,7 +1441,7 @@ class TestAttrComp(base.BaseTestCase):
             'CpusetMems': '', 'MemorySwap': 0, 'MemoryReservation': 0,
             'Ulimits': []}
         self.dw = get_DockerWorker(self.fake_data['params'])
-        self.assertTrue(self.dw.compare_dimensions(container_info))
+        self.assertFalse(self.dw.compare_dimensions(container_info))
 
     def test_compare_dimensions_removed_and_changed(self):
         self.fake_data['params']['dimensions'] = {

--- a/tests/kolla_container_tests/test_podman_worker.py
+++ b/tests/kolla_container_tests/test_podman_worker.py
@@ -1337,7 +1337,7 @@ class TestAttrComp(base.BaseTestCase):
             'CpusetMems': '', 'MemorySwap': 0, 'MemoryReservation': 0,
             'Ulimits': []}
         self.pw = get_PodmanWorker(self.fake_data['params'])
-        self.assertTrue(self.pw.compare_dimensions(container_info))
+        self.assertFalse(self.pw.compare_dimensions(container_info))
 
     def test_compare_dimensions_removed_and_changed(self):
         self.fake_data['params']['dimensions'] = {


### PR DESCRIPTION
## Summary
- handle empty dimensions param correctly
- improve debug output in compare_dimensions
- update docker and podman worker tests

## Testing
- `pytest -k compare_empty_dimensions` *(fails: ModuleNotFoundError: No module named 'jinja2')*
- `pip install tox` *(fails: Could not find a version that satisfies the requirement tox)*

------
https://chatgpt.com/codex/tasks/task_e_686d285f9bb08327a9c6268d72141f56