### PR TITLE
fix-dimension-compare-empty

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -477,6 +477,7 @@ class ContainerWorker(ABC):
     def compare_dimensions(self, container_info):
         """Return True if requested dimensions differ from the container."""
         new_dimensions = _as_dict(self.params.get("dimensions"))
+        # Nothing requested – nothing to compare
         if not new_dimensions:
             return False
         unsupported = set(new_dimensions) - set(self.dimension_map)

--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -334,6 +334,9 @@ class PodmanWorker(ContainerWorker):
 
     def compare_dimensions(self, container_info):
         new_dimensions = _as_dict(self.params.get("dimensions"))
+        # Nothing requested – nothing to compare
+        if not new_dimensions:
+            return False
 
         # NOTE(mgoddard): The names used by Docker/Podman are inconsistent
         # between configuration of a container's resources and


### PR DESCRIPTION
## Summary
- skip dimension compare when no dimensions requested

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d2b774da08327afc0da741ae71446