### PR TITLE
Add custom collectd plugin config copy

### DIFF
--- a/ansible/roles/collectd/tasks/config.yml
+++ b/ansible/roles/collectd/tasks/config.yml
@@ -19,6 +19,21 @@
   become: true
   with_dict: "{{ collectd_services | select_services_enabled_and_mapped_to_host }}"
 
+- name: Copying over custom collectd plugin configuration
+  vars:
+    service: "{{ collectd_services['collectd'] }}"
+  copy:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/collectd/collectd.conf.d/"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_user }}"
+    mode: "0660"
+  become: true
+  when: service | service_enabled_and_mapped_to_host
+  with_fileglob:
+    - "{{ node_custom_config }}/collectd/collectd.conf.d/*.conf"
+    - "{{ node_custom_config }}/collectd/{{ inventory_hostname }}/collectd.conf.d/*.conf"
+
 - name: Copying over config.json files for services
   template:
     src: "{{ item.key }}.json.j2"


### PR DESCRIPTION
## Summary
- copy custom collectd plugin files from node_custom_config
- preserve config ownership and permissions

## Testing
- `pip install tox` *(fails: Tunnel connection failed)*
- `tox -e linters` *(not run due to missing tox)*
- `kolla-ansible deploy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5f3bb3a08327b9480e53f3493586