### PR TITLE
Add custom collectd plugin config copy

### DIFF
--- a/ansible/roles/collectd/tasks/config.yml
+++ b/ansible/roles/collectd/tasks/config.yml
@@ -15,9 +15,24 @@
     state: "directory"
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
-    mode: "0770"
+    mode: "0755"
   become: true
   with_dict: "{{ collectd_services | select_services_enabled_and_mapped_to_host }}"
+
+- name: Copying over custom collectd plugin configuration
+  vars:
+    service: "{{ collectd_services['collectd'] }}"
+  copy:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/collectd/collectd.conf.d/"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0660"
+  become: true
+  when: service | service_enabled_and_mapped_to_host
+  with_fileglob:
+    - "{{ node_custom_config }}/collectd/collectd.conf.d/*.conf"
+    - "{{ node_custom_config }}/collectd/{{ inventory_hostname }}/collectd.conf.d/*.conf"
 
 - name: Copying over config.json files for services
   template:


### PR DESCRIPTION
## Summary
- copy custom collectd plugin files from node_custom_config
- preserve config ownership and permissions
- ensure plugin directory is readable inside the container

## Testing
- `pip install tox` *(fails: Tunnel connection failed)*
- `tox -e linters` *(fails: command not found)*
- `kolla-ansible deploy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5f3bb3a08327b9480e53f3493586