### PR TITLE
Fix collectd config ownership defaults

### DIFF
--- a/ansible/roles/collectd/defaults/main.yml
+++ b/ansible/roles/collectd/defaults/main.yml
@@ -33,5 +33,5 @@ collectd_extra_volumes: "{{ default_extra_volumes }}"
 ####################
 collectd_logging_debug: "{{ openstack_logging_debug }}"
 
-collectd_user: "collectd"
-collectd_group: "collectd"
+collectd_user: "{{ config_owner_user }}"
+collectd_group: "{{ config_owner_group }}"


### PR DESCRIPTION
## Summary
- fix collectd defaults to use config_owner variables

## Testing
- `pip install tox` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686e66305a4483278b824108f87a9096