### PR TITLE
Fix collectd config ownership

### DIFF
--- a/ansible/roles/collectd/defaults/main.yml
+++ b/ansible/roles/collectd/defaults/main.yml
@@ -33,5 +33,5 @@ collectd_extra_volumes: "{{ default_extra_volumes }}"
 ####################
 collectd_logging_debug: "{{ openstack_logging_debug }}"
 
-collectd_user: "{{ config_owner_user }}"
-collectd_group: "{{ config_owner_group }}"
+collectd_user: "collectd"
+collectd_group: "collectd"

--- a/releasenotes/notes/collectd-config-ownership-e0a94a6b1882.yaml
+++ b/releasenotes/notes/collectd-config-ownership-e0a94a6b1882.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    The collectd role now ensures that files and directories in ``/etc/collectd``
+    inside the container are owned by the ``collectd`` user and group by default.


### PR DESCRIPTION
## Summary
- ensure collectd config in container uses collectd user
- add release note for collectd ownership fix

## Testing
- `tox -e linters` *(fails: tox not installed)*
- `pip install tox` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e6801b9188327bd84e1b0d6ea8b2a