### PR TITLE
Fix collectd plugin directory ownership

### DIFF
--- a/ansible/roles/collectd/tasks/config.yml
+++ b/ansible/roles/collectd/tasks/config.yml
@@ -9,15 +9,31 @@
   become: true
   with_dict: "{{ collectd_services | select_services_enabled_and_mapped_to_host }}"
 
+- name: Get collectd uid
+  become: true
+  command: "{{ kolla_container_engine }} run --rm {{ collectd_image_full }} id -u collectd"
+  register: collectd_uid_result
+  changed_when: false
+
+- name: Get collectd gid
+  become: true
+  command: "{{ kolla_container_engine }} run --rm {{ collectd_image_full }} id -g collectd"
+  register: collectd_gid_result
+  changed_when: false
+
+- name: Set collectd uid and gid facts
+  set_fact:
+    collectd_uid: "{{ collectd_uid_result.stdout }}"
+    collectd_gid: "{{ collectd_gid_result.stdout }}"
+
 - name: Ensuring Plugin directory exist
   file:
-    path: "{{ node_config_directory }}/{{ item.key }}/collectd.conf.d"
+    path: "{{ node_config_directory }}/collectd/collectd.conf.d"
     state: "directory"
-    owner: "collectd"
-    group: "collectd"
+    owner: "{{ collectd_uid }}"
+    group: "{{ collectd_gid }}"
     mode: "0755"
   become: true
-  with_dict: "{{ collectd_services | select_services_enabled_and_mapped_to_host }}"
 
 - name: Copying over custom collectd plugin configuration
   vars:
@@ -25,8 +41,8 @@
   copy:
     src: "{{ item }}"
     dest: "{{ node_config_directory }}/collectd/collectd.conf.d/"
-    owner: "collectd"
-    group: "collectd"
+    owner: "{{ collectd_uid }}"
+    group: "{{ collectd_gid }}"
     mode: "0660"
   become: true
   when: service | service_enabled_and_mapped_to_host
@@ -65,6 +81,6 @@
   file:
     path: "{{ node_config_directory }}/collectd"
     recurse: yes
-    owner: "collectd"
-    group: "collectd"
+    owner: "{{ collectd_uid }}"
+    group: "{{ collectd_gid }}"
   become: true


### PR DESCRIPTION
## Summary
- ensure collectd config directory `collectd.conf.d` exists
- create it with UID/GID of collectd from the container
- copy custom plugin configs using correct ownership

## Testing
- `tox -e linters` *(fails: `tox: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e6bf22e1c83279bd20f7f76088460