### PR TITLE
Fix Podman diff flapping in service-check-containers

### DIFF
--- a/releasenotes/notes/podman-diff-normalisation-b1f6a8e9b2a6e8bd.yaml
+++ b/releasenotes/notes/podman-diff-normalisation-b1f6a8e9b2a6e8bd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Normalises Podman volume and ulimit comparisons in the
+    ``service-check-containers`` role to avoid spurious "volumes differ"
+    and "dimensions differ" warnings.


### PR DESCRIPTION
## Summary
- normalise volumes and ulimits before comparing Podman containers
- skip missing ulimit keys when comparing
- ensure blank volumes and devpts mount are ignored
- add regression unit tests
- document the fix

## Testing
- `pytest -k test_compare_volumes_ignores_empty_and_devpts tests/test_kolla_container.py` *(fails: ModuleNotFoundError: No module named 'oslotest')*


------
https://chatgpt.com/codex/tasks/task_e_686e872a5d608327b606c480c30d4756