### PR TITLE
Implement secret distribution for bootstrap

### DIFF
--- a/ansible/kolla-host.yml
+++ b/ansible/kolla-host.yml
@@ -12,3 +12,12 @@
   roles:
     - { role: openstack.kolla.baremetal,
         tags: baremetal }
+
+- name: Distribute service secrets
+  hosts: all
+  serial: '{{ kolla_serial|default("0") }}'
+  gather_facts: false
+  max_fail_percentage: >-
+    {{ secrets_max_fail_percentage | default(kolla_max_fail_percentage) | default(100) }}
+  roles:
+    - distribute-secrets

--- a/ansible/roles/distribute-secrets/defaults/main.yml
+++ b/ansible/roles/distribute-secrets/defaults/main.yml
@@ -1,0 +1,3 @@
+# Defaults for distribute-secrets role
+kolla_secrets_src: /etc/kolla/config/secrets
+kolla_secrets_dest: /etc/kolla/secrets

--- a/ansible/roles/distribute-secrets/tasks/main.yml
+++ b/ansible/roles/distribute-secrets/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+- name: Check if secrets source directory exists
+  delegate_to: localhost
+  run_once: true
+  stat:
+    path: "{{ kolla_secrets_src }}"
+  register: _secrets_root
+
+- name: Find group secret directories
+  delegate_to: localhost
+  run_once: true
+  find:
+    paths: "{{ kolla_secrets_src }}"
+    file_type: directory
+    depth: 1
+  register: _secret_dirs
+  when: _secrets_root.stat.exists
+
+- name: Gather files for each secret directory
+  delegate_to: localhost
+  run_once: true
+  when: _secret_dirs.files is defined
+  loop: "{{ _secret_dirs.files }}"
+  loop_control:
+    loop_var: _dir
+    label: "{{ _dir.path }}"
+  find:
+    paths: "{{ _dir.path }}"
+    file_type: file
+  register: _secret_files_results
+
+- name: Build secret files mapping
+  delegate_to: localhost
+  run_once: true
+  set_fact:
+    kolla_secret_files: "{{ kolla_secret_files | default({}) | combine({ (_item.item.path | basename): _item.files }) }}"
+  loop: "{{ _secret_files_results.results | default([]) }}"
+  loop_control:
+    loop_var: _item
+
+- name: Debug empty secret directories
+  delegate_to: localhost
+  run_once: true
+  debug:
+    msg: "Secret directory {{ _item.item.path }} exists but contains no files"
+  when:
+    - _item.matched | default(0) | int == 0
+  loop: "{{ _secret_files_results.results | default([]) }}"
+  loop_control:
+    loop_var: _item
+
+- name: Share secret files mapping with all hosts
+  set_fact:
+    kolla_secret_files: "{{ hostvars['localhost'].kolla_secret_files | default({}) }}"
+
+- name: Process secrets for host groups
+  block:
+    - name: Debug processing group
+      debug:
+        msg: "Processing secrets for group {{ group }}"
+    - name: Ensure destination directory exists
+      become: true
+      file:
+        path: "{{ kolla_secrets_dest }}/{{ group }}"
+        state: directory
+        mode: '0700'
+    - name: Copy secret files for group
+      become: true
+      copy:
+        src: "{{ item.path }}"
+        dest: "{{ kolla_secrets_dest }}/{{ group }}/{{ item.path | basename }}"
+        owner: root
+        group: root
+        mode: "{{ item.mode if (item.mode | int(base=8)) <= 420 else '0644' }}"
+      loop: "{{ kolla_secret_files[group] }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+    - name: Debug copied files
+      debug:
+        msg: "Copied {{ kolla_secret_files[group] | length }} files for group {{ group }}"
+  when: kolla_secret_files.get(group) is defined and kolla_secret_files[group] | length > 0
+  vars:
+    my_groups: "{{ group_names }}"
+  loop: "{{ my_groups }}"
+  loop_control:
+    loop_var: group
+    label: "{{ group }}"
+
+- name: Debug groups skipped
+  debug:
+    msg: "No secrets found for group {{ group }} - skipping"
+  when: kolla_secret_files.get(group) is not defined or kolla_secret_files[group] | length == 0
+  vars:
+    my_groups: "{{ group_names }}"
+  loop: "{{ my_groups }}"
+  loop_control:
+    loop_var: group
+    label: "{{ group }}"

--- a/distribute-kolla-secrets.md
+++ b/distribute-kolla-secrets.md
@@ -1,0 +1,42 @@
+# Distributing Kolla Secrets
+
+This feature allows administrators to organise service specific secret files on
+the deploy host and automatically distribute them to the correct hosts during
+`kolla-ansible bootstrap-servers`.
+
+## Organising Secrets
+
+On the deploy host place files under `/etc/kolla/config/secrets/<group>/` where
+`<group>` matches an inventory group name. All files in such a directory will be
+copied to `/etc/kolla/secrets/<group>/` on hosts belonging to that group.
+
+Example:
+
+```text
+/etc/kolla/config/secrets/nova/gitlab_key.pub
+```
+
+After running `kolla-ansible bootstrap-servers` the file will be available on
+all hosts in the `nova` group as:
+
+```text
+/etc/kolla/secrets/nova/gitlab_key.pub
+```
+
+## Integration with bootstrap-servers
+
+No additional commands are required. When `bootstrap-servers` runs it now calls
+an additional role that performs the distribution. The destination directory is
+created with `0700` permissions and files default to `0644`. More restrictive
+source permissions such as `0600` are preserved.
+
+Empty directories are skipped with a debug message and directories that do not
+exist are silently ignored. The tasks are idempotent and safe to run multiple
+times.
+
+## Security and Idempotency
+
+Secrets should be readable only by the deploy user and stored securely. Ensure
+the `/etc/kolla/config/secrets/` hierarchy on the deploy host is protected. Logs
+provide information about which groups and files were processed. Because the
+copy operation is idempotent it may be executed safely in CI environments.


### PR DESCRIPTION
## Summary
- add a new role `distribute-secrets`
- integrate role into `bootstrap-servers` workflow
- document how to distribute group secrets

## Testing
- `ansible-lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9fa733ac83279262776212c0abeb