### PR TITLE
Fix distribute-secrets loop handling

### DIFF
--- a/ansible/roles/distribute-secrets/tasks/main.yml
+++ b/ansible/roles/distribute-secrets/tasks/main.yml
@@ -54,31 +54,10 @@
     kolla_secret_files: "{{ hostvars['localhost'].kolla_secret_files | default({}) }}"
 
 - name: Process secrets for host groups
-  block:
-    - name: Debug processing group
-      debug:
-        msg: "Processing secrets for group {{ group }}"
-    - name: Ensure destination directory exists
-      become: true
-      file:
-        path: "{{ kolla_secrets_dest }}/{{ group }}"
-        state: directory
-        mode: '0700'
-    - name: Copy secret files for group
-      become: true
-      copy:
-        src: "{{ item.path }}"
-        dest: "{{ kolla_secrets_dest }}/{{ group }}/{{ item.path | basename }}"
-        owner: root
-        group: root
-        mode: "{{ item.mode if (item.mode | int(base=8)) <= 420 else '0644' }}"
-      loop: "{{ kolla_secret_files[group] }}"
-      loop_control:
-        label: "{{ item.path | basename }}"
-    - name: Debug copied files
-      debug:
-        msg: "Copied {{ kolla_secret_files[group] | length }} files for group {{ group }}"
-  when: kolla_secret_files.get(group) is defined and kolla_secret_files[group] | length > 0
+  include_tasks: process_group.yml
+  when:
+    - kolla_secret_files.get(group) is defined
+    - kolla_secret_files[group] | length > 0
   vars:
     my_groups: "{{ group_names }}"
   loop: "{{ my_groups }}"

--- a/ansible/roles/distribute-secrets/tasks/process_group.yml
+++ b/ansible/roles/distribute-secrets/tasks/process_group.yml
@@ -1,0 +1,24 @@
+---
+- name: Debug processing group
+  debug:
+    msg: "Processing secrets for group {{ group }}"
+- name: Ensure destination directory exists
+  become: true
+  file:
+    path: "{{ kolla_secrets_dest }}/{{ group }}"
+    state: directory
+    mode: '0700'
+- name: Copy secret files for group
+  become: true
+  copy:
+    src: "{{ item.path }}"
+    dest: "{{ kolla_secrets_dest }}/{{ group }}/{{ item.path | basename }}"
+    owner: root
+    group: root
+    mode: "{{ item.mode if (item.mode | int(base=8)) <= 420 else '0644' }}"
+  loop: "{{ kolla_secret_files[group] }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+- name: Debug copied files
+  debug:
+    msg: "Copied {{ kolla_secret_files[group] | length }} files for group {{ group }}"


### PR DESCRIPTION
## Summary
- fix distribute-secrets role by replacing block loop with include_tasks
- add a dedicated task file for handling each group

## Testing
- `python3 -m pip install tox` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_686fa21467f0832783ef9155bcd4e63e