### PR TITLE
Fix distribute-secrets loop condition

### DIFF
--- a/ansible/roles/distribute-secrets/tasks/main.yml
+++ b/ansible/roles/distribute-secrets/tasks/main.yml
@@ -29,12 +29,19 @@
     file_type: file
   register: _secret_files_results
 
-- name: Build secret files mapping
+- name: Ensure secret files fact exists
   delegate_to: localhost
   run_once: true
   set_fact:
-    kolla_secret_files: "{{ kolla_secret_files | default({}) | combine({ (_item.item.path | basename): _item.files }) }}"
-  loop: "{{ _secret_files_results.results | default([]) }}"
+    kolla_secret_files: "{{ kolla_secret_files | default({}) }}"
+
+- name: Build secret files mapping
+  delegate_to: localhost
+  run_once: true
+  when: _secret_files_results is defined
+  set_fact:
+    kolla_secret_files: "{{ kolla_secret_files | combine({ (_item.item.path | basename): _item.files }) }}"
+  loop: "{{ _secret_files_results.results }}"
   loop_control:
     loop_var: _item
 


### PR DESCRIPTION
## Summary
- ensure kolla_secret_files fact exists
- guard building the secret file map when no files are discovered

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fa413b99883278ee5bca2369ab672