### PR TITLE
Fix secret group processing

### DIFF
--- a/ansible/roles/distribute-secrets/tasks/main.yml
+++ b/ansible/roles/distribute-secrets/tasks/main.yml
@@ -77,9 +77,7 @@
 
 - name: Process secrets for host groups
   include_tasks: process_group.yml
-  when:
-    - kolla_secret_files.get(group) is defined
-    - kolla_secret_files[group] | length > 0
+  when: kolla_secret_files.get(group, []) | length > 0
   vars:
     inventory_meta_groups: "{{ ['all', 'ungrouped'] + (groups.keys() | select('match','^all_') | list) }}"
     my_groups: "{{ group_names | difference(inventory_meta_groups) }}"
@@ -91,7 +89,7 @@
 - name: Debug groups skipped
   debug:
     msg: "No secrets found for group {{ group }} - skipping"
-  when: kolla_secret_files.get(group) is not defined or kolla_secret_files[group] | length == 0
+  when: kolla_secret_files.get(group, []) | length == 0
   vars:
     inventory_meta_groups: "{{ ['all', 'ungrouped'] + (groups.keys() | select('match','^all_') | list) }}"
     my_groups: "{{ group_names | difference(inventory_meta_groups) }}"

--- a/ansible/roles/distribute-secrets/tasks/process_group.yml
+++ b/ansible/roles/distribute-secrets/tasks/process_group.yml
@@ -16,9 +16,9 @@
     owner: root
     group: root
     mode: "{{ item.mode if (item.mode | int(base=8)) <= 420 else '0644' }}"
-  loop: "{{ kolla_secret_files[group] }}"
+  loop: "{{ kolla_secret_files.get(group, []) }}"
   loop_control:
     label: "{{ item.path | basename }}"
 - name: Debug copied files
   debug:
-    msg: "Copied {{ kolla_secret_files[group] | length }} files for group {{ group }}"
+    msg: "Copied {{ kolla_secret_files.get(group, []) | length }} files for group {{ group }}"


### PR DESCRIPTION
## Summary
- handle missing groups when distributing secret files

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fba1f0db08327a6b5ea76121130a7