### PR TITLE
Fix distribute-secrets fact propagation

### DIFF
--- a/ansible/roles/distribute-secrets/tasks/main.yml
+++ b/ansible/roles/distribute-secrets/tasks/main.yml
@@ -72,12 +72,16 @@
     loop_var: _item
 
 - name: Share secret files mapping with all hosts
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  run_once: true
   set_fact:
     kolla_secret_files: "{{ hostvars['localhost'].kolla_secret_files | default({}) }}"
+  loop: "{{ ansible_play_hosts_all }}"
 
 - name: Process secrets for host groups
   include_tasks: process_group.yml
-  when: kolla_secret_files.get(group, []) | length > 0
+  when: (kolla_secret_files | default({})).get(group, []) | length > 0
   vars:
     inventory_meta_groups: "{{ ['all', 'ungrouped'] + (groups.keys() | select('match','^all_') | list) }}"
     my_groups: "{{ group_names | difference(inventory_meta_groups) }}"
@@ -89,7 +93,7 @@
 - name: Debug groups skipped
   debug:
     msg: "No secrets found for group {{ group }} - skipping"
-  when: kolla_secret_files.get(group, []) | length == 0
+  when: (kolla_secret_files | default({})).get(group, []) | length == 0
   vars:
     inventory_meta_groups: "{{ ['all', 'ungrouped'] + (groups.keys() | select('match','^all_') | list) }}"
     my_groups: "{{ group_names | difference(inventory_meta_groups) }}"


### PR DESCRIPTION
## Summary
- ensure kolla_secret_files fact is copied to all hosts
- avoid conditional errors if fact is missing

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fbb8f7a8c832789ec4336dffbcab3