### PR TITLE
Fix secret files distribution logic

### DIFF
--- a/ansible/roles/distribute-secrets/tasks/main.yml
+++ b/ansible/roles/distribute-secrets/tasks/main.yml
@@ -30,12 +30,14 @@
 
 - name: Ensure secret files fact exists
   delegate_to: localhost
+  delegate_facts: true
   run_once: true
   set_fact:
     kolla_secret_files: "{{ kolla_secret_files | default({}) }}"
 
 - name: Build secret files mapping
   delegate_to: localhost
+  delegate_facts: true
   run_once: true
   when: _secret_files_results.results is defined
   set_fact:


### PR DESCRIPTION
## Summary
- ensure secret file facts are stored on localhost

## Testing
- `tox -e linters --notest` *(fails: tox not installed)*
- `pip install tox` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686fbd49a62c8327abb80ff038408c7c