### PR TITLE
Fix secret files delegate fact scoping

### DIFF
--- a/ansible/roles/distribute-secrets/tasks/main.yml
+++ b/ansible/roles/distribute-secrets/tasks/main.yml
@@ -33,7 +33,7 @@
   delegate_facts: true
   run_once: true
   set_fact:
-    kolla_secret_files: "{{ kolla_secret_files | default({}) }}"
+    kolla_secret_files: "{{ hostvars['localhost'].kolla_secret_files | default({}) }}"
 
 - name: Build secret files mapping
   delegate_to: localhost
@@ -41,7 +41,7 @@
   run_once: true
   when: _secret_files_results.results is defined
   set_fact:
-    kolla_secret_files: "{{ kolla_secret_files | combine({ (_item.item.path | basename): _item.files }) }}"
+    kolla_secret_files: "{{ hostvars['localhost'].kolla_secret_files | default({}) | combine({ (_item.item.path | basename): _item.files }) }}"
   loop: "{{ _secret_files_results.results
             | selectattr('item', 'defined')
             | selectattr('matched', 'gt', 0)


### PR DESCRIPTION
## Summary
- ensure distribute-secrets role uses localhost scoped fact for secret file mapping

## Testing
- `tox -e linters` *(fails: tox not installed and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686fbe8b6d0c8327b3a21019de4a1f6d