### PR TITLE
Run ovs cleanup before start of neutron agent

### DIFF
--- a/ansible/roles/neutron/tasks/config-neutron-fake.yml
+++ b/ansible/roles/neutron/tasks/config-neutron-fake.yml
@@ -60,6 +60,21 @@
   notify:
     - Restart fake neutron-openvswitch-agent container
 
+- name: Copy neutron-openvswitch-agent-wrapper script
+  become: true
+  vars:
+    service_name: "{{ item }}"
+  template:
+    src: neutron-openvswitch-agent-wrapper.sh.j2
+    dest: "{{ node_config_directory }}/neutron-openvswitch-agent-fake-{{ item }}/neutron-openvswitch-agent-wrapper.sh"
+    mode: "0770"
+  with_sequence: start=1 end={{ num_nova_fake_per_node }}
+  when:
+    - inventory_hostname in groups['compute']
+    - neutron_plugin_agent == "openvswitch"
+  notify:
+    - Restart fake neutron-openvswitch-agent container
+
 - name: Checking neutron-openvswitch-agent container for nova fake node
   vars:
     neutron_openvswitch_agent: "{{ neutron_services['neutron-openvswitch-agent'] }}"

--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -177,6 +177,17 @@
     mode: "0660"
   when: service | service_enabled_and_mapped_to_host
 
+- name: Copy neutron-openvswitch-agent-wrapper script
+  become: true
+  vars:
+    service_name: "neutron-openvswitch-agent"
+    service: "{{ neutron_services[service_name] }}"
+  template:
+    src: neutron-openvswitch-agent-wrapper.sh.j2
+    dest: "{{ node_config_directory }}/{{ service_name }}/neutron-openvswitch-agent-wrapper.sh"
+    mode: "0770"
+  when: service | service_enabled_and_mapped_to_host
+
 - name: Copying over sriov_agent.ini
   become: true
   vars:

--- a/ansible/roles/neutron/templates/neutron-openvswitch-agent-wrapper.sh.j2
+++ b/ansible/roles/neutron/templates/neutron-openvswitch-agent-wrapper.sh.j2
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+
+neutron-ovs-cleanup \
+        --config-file /etc/neutron/neutron.conf \
+        --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini
+
+neutron-openvswitch-agent \
+        --config-file /etc/neutron/neutron.conf \
+        --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini
+

--- a/ansible/roles/neutron/templates/neutron-openvswitch-agent-xenapi.json.j2
+++ b/ansible/roles/neutron/templates/neutron-openvswitch-agent-xenapi.json.j2
@@ -1,6 +1,12 @@
 {
-    "command": "neutron-openvswitch-agent --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini",
+    "command": "/usr/local/bin/neutron-openvswitch-agent-wrapper.sh",
     "config_files": [
+        {
+            "source": "{{ container_config_directory }}/neutron-openvswitch-agent-wrapper.sh",
+            "dest": "/usr/local/bin/neutron-openvswitch-agent-wrapper.sh",
+            "owner": "root",
+            "perm": "0755"
+        },
         {
             "source": "{{ container_config_directory }}/neutron.conf",
             "dest": "/etc/neutron/neutron.conf",

--- a/ansible/roles/neutron/templates/neutron-openvswitch-agent.json.j2
+++ b/ansible/roles/neutron/templates/neutron-openvswitch-agent.json.j2
@@ -1,6 +1,12 @@
 {
-    "command": "neutron-openvswitch-agent --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini",
+    "command": "/usr/local/bin/neutron-openvswitch-agent-wrapper.sh",
     "config_files": [
+        {
+            "source": "{{ container_config_directory }}/neutron-openvswitch-agent-wrapper.sh",
+            "dest": "/usr/local/bin/neutron-openvswitch-agent-wrapper.sh",
+            "owner": "root",
+            "perm": "0755"
+        },
         {
             "source": "{{ container_config_directory }}/neutron.conf",
             "dest": "/etc/neutron/neutron.conf",

--- a/releasenotes/notes/neutron-ovs-cleanup-wrapper-0cfe3330e2747cb2.yaml
+++ b/releasenotes/notes/neutron-ovs-cleanup-wrapper-0cfe3330e2747cb2.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Ensure ``neutron-ovs-cleanup`` is run before starting the
+    ``neutron-openvswitch-agent`` container to remove any stale Open
+    vSwitch ports.


### PR DESCRIPTION
## Summary
- ensure neutron-ovs-cleanup runs before the agent in the container
- add wrapper script for neutron-openvswitch-agent
- deploy wrapper script for fake compute nodes
- document the change in release notes

## Testing
- `tox -e linters` *(fails: tox missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877aaca93c88327b4c5a89f3baa34d2