### PR TITLE
Fix neutron-ovs-cleanup container config

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -9,6 +9,65 @@
     mode: "0770"
   with_dict: "{{ neutron_services | select_services_enabled_and_mapped_to_host }}"
 
+- name: Ensuring neutron-ovs-cleanup config directory exists
+  become: true
+  vars:
+    service_name: "neutron-openvswitch-agent"
+    service: "{{ neutron_services[service_name] }}"
+  file:
+    path: "{{ node_config_directory }}/neutron-ovs-cleanup"
+    state: "directory"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0770"
+  when: service | service_enabled_and_mapped_to_host
+
+- name: Copy neutron-ovs-cleanup config files
+  become: true
+  vars:
+    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
+    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
+  copy:
+    remote_src: true
+    src: "{{ item }}"
+    dest: "{{ cleanup_dir }}/{{ item | basename }}"
+    mode: "0660"
+  loop:
+    - "{{ ovs_agent_dir }}/config.json"
+    - "{{ ovs_agent_dir }}/neutron.conf"
+    - "{{ ovs_agent_dir }}/openvswitch_agent.ini"
+  when: service | service_enabled_and_mapped_to_host
+
+- name: Copy neutron-ovs-cleanup ML2 plugin configs
+  become: true
+  vars:
+    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
+    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
+  copy:
+    remote_src: true
+    src: "{{ ovs_agent_dir }}/{{ item.path | basename }}"
+    dest: "{{ cleanup_dir }}/{{ item.path | basename }}"
+    mode: "0660"
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - check_extra_ml2_plugins is defined
+    - check_extra_ml2_plugins.matched > 0
+  loop: "{{ check_extra_ml2_plugins.files }}"
+
+- name: Copy neutron-ovs-cleanup policy file
+  become: true
+  vars:
+    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
+    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
+  copy:
+    remote_src: true
+    src: "{{ ovs_agent_dir }}/{{ neutron_policy_file }}"
+    dest: "{{ cleanup_dir }}/{{ neutron_policy_file }}"
+    mode: "0660"
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - neutron_policy_file is defined
+
 - name: Check if extra ml2 plugins exists
   find:
     path: "{{ node_custom_config }}/neutron/plugins/"

--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -16,5 +16,7 @@
     name: "neutron_ovs_cleanup"
     restart_policy: no
     remove_on_exit: true
-    volumes: "{{ service.volumes | reject('equalto', '') | list }}"
+    volumes: >-
+      {{ [ node_config_directory ~ '/neutron-ovs-cleanup/:{{ container_config_directory }}/:ro' ]
+         + (service.volumes[1:] | list) }}
   when: service | service_enabled_and_mapped_to_host


### PR DESCRIPTION
## Summary
- copy neutron-openvswitch-agent config files for neutron-ovs-cleanup
- mount the new configuration directory when running neutron-ovs-cleanup

## Testing
- `pip install tox` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877bf057e948327ac24dbb1f3265d55