### PR TITLE
Fix neutron-ovs-cleanup volume path

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -16,7 +16,5 @@
     name: "neutron_ovs_cleanup"
     restart_policy: no
     remove_on_exit: true
-    volumes: >-
-      {{ [ node_config_directory ~ '/neutron-ovs-cleanup/:{{ container_config_directory }}/:ro' ]
-         + (service.volumes[1:] | list) }}
+    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup:' ~ container_config_directory ~ '/:ro' ] + (service.volumes[1:] | list) }}"
   when: service | service_enabled_and_mapped_to_host


### PR DESCRIPTION
## Summary
- fix expansion of `container_config_directory` when building the volumes list for the neutron-ovs-cleanup container

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6877c2e01bc88327a3ade83c146f0da2