### PR TITLE
Fix neutron-ovs-cleanup volume path

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -16,5 +16,5 @@
     name: "neutron_ovs_cleanup"
     restart_policy: no
     remove_on_exit: true
-    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup:' ~ container_config_directory ~ '/:ro' ] + (service.volumes[1:] | list) }}"
+    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro' ] + (service.volumes[1:] | list) }}"
   when: service | service_enabled_and_mapped_to_host


### PR DESCRIPTION
## Summary
- fix neutron-ovs-cleanup container volume path

## Testing
- `pip install tox` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6877c40fe6ac8327b66b357efb1cde15