### PR TITLE
Fix permission error on neutron-ovs-cleanup

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -9,7 +9,7 @@
     common_options: "{{ docker_common_options }}"
     detach: False
     command: >-
-      bash -c 'kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini'
+      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini'
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP:


### PR DESCRIPTION
## Summary
- run kolla_set_configs with sudo inside the neutron_ovs_cleanup container

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6877c6121b1483279eb90fed2b9b8171