### PR TITLE
Fix neutron-ovs-cleanup config timing

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -22,57 +22,6 @@
     mode: "0770"
   when: service | service_enabled_and_mapped_to_host
 
-- name: Copy neutron-ovs-cleanup config files
-  become: true
-  vars:
-    service_name: "neutron-openvswitch-agent"
-    service: "{{ neutron_services[service_name] }}"
-    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
-    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
-  copy:
-    remote_src: true
-    src: "{{ item }}"
-    dest: "{{ cleanup_dir }}/{{ item | basename }}"
-    mode: "0660"
-  loop:
-    - "{{ ovs_agent_dir }}/config.json"
-    - "{{ ovs_agent_dir }}/neutron.conf"
-    - "{{ ovs_agent_dir }}/openvswitch_agent.ini"
-  when: service | service_enabled_and_mapped_to_host
-
-- name: Copy neutron-ovs-cleanup ML2 plugin configs
-  become: true
-  vars:
-    service_name: "neutron-openvswitch-agent"
-    service: "{{ neutron_services[service_name] }}"
-    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
-    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
-  copy:
-    remote_src: true
-    src: "{{ ovs_agent_dir }}/{{ item.path | basename }}"
-    dest: "{{ cleanup_dir }}/{{ item.path | basename }}"
-    mode: "0660"
-  when:
-    - service | service_enabled_and_mapped_to_host
-    - check_extra_ml2_plugins is defined
-    - check_extra_ml2_plugins.matched > 0
-  loop: "{{ check_extra_ml2_plugins.files }}"
-
-- name: Copy neutron-ovs-cleanup policy file
-  become: true
-  vars:
-    service_name: "neutron-openvswitch-agent"
-    service: "{{ neutron_services[service_name] }}"
-    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
-    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
-  copy:
-    remote_src: true
-    src: "{{ ovs_agent_dir }}/{{ neutron_policy_file }}"
-    dest: "{{ cleanup_dir }}/{{ neutron_policy_file }}"
-    mode: "0660"
-  when:
-    - service | service_enabled_and_mapped_to_host
-    - neutron_policy_file is defined
 
 - name: Check if extra ml2 plugins exists
   find:
@@ -507,3 +456,55 @@
     - enable_neutron_taas | bool
     - item.key in services_need_neutron_taas_conf
   with_dict: "{{ neutron_services | select_services_enabled_and_mapped_to_host }}"
+
+- name: Copy neutron-ovs-cleanup config files
+  become: true
+  vars:
+    service_name: "neutron-openvswitch-agent"
+    service: "{{ neutron_services[service_name] }}"
+    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
+    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
+  copy:
+    remote_src: true
+    src: "{{ item }}"
+    dest: "{{ cleanup_dir }}/{{ item | basename }}"
+    mode: "0660"
+  loop:
+    - "{{ ovs_agent_dir }}/config.json"
+    - "{{ ovs_agent_dir }}/neutron.conf"
+    - "{{ ovs_agent_dir }}/openvswitch_agent.ini"
+  when: service | service_enabled_and_mapped_to_host
+
+- name: Copy neutron-ovs-cleanup ML2 plugin configs
+  become: true
+  vars:
+    service_name: "neutron-openvswitch-agent"
+    service: "{{ neutron_services[service_name] }}"
+    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
+    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
+  copy:
+    remote_src: true
+    src: "{{ ovs_agent_dir }}/{{ item.path | basename }}"
+    dest: "{{ cleanup_dir }}/{{ item.path | basename }}"
+    mode: "0660"
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - check_extra_ml2_plugins is defined
+    - check_extra_ml2_plugins.matched > 0
+  loop: "{{ check_extra_ml2_plugins.files }}"
+
+- name: Copy neutron-ovs-cleanup policy file
+  become: true
+  vars:
+    service_name: "neutron-openvswitch-agent"
+    service: "{{ neutron_services[service_name] }}"
+    ovs_agent_dir: "{{ node_config_directory }}/neutron-openvswitch-agent"
+    cleanup_dir: "{{ node_config_directory }}/neutron-ovs-cleanup"
+  copy:
+    remote_src: true
+    src: "{{ ovs_agent_dir }}/{{ neutron_policy_file }}"
+    dest: "{{ cleanup_dir }}/{{ neutron_policy_file }}"
+    mode: "0660"
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - neutron_policy_file is defined


### PR DESCRIPTION
## Summary
- ensure neutron-ovs-cleanup uses the latest openvswitch config by copying the files after they are generated

## Testing
- `tox -e linters` *(fails: Could not install tox)*

------
https://chatgpt.com/codex/tasks/task_e_6878db803f7883279199b2e4ab3f1124