### PR TITLE
Ensure neutron-ovs-cleanup runs only once per boot

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -988,3 +988,8 @@ neutron_dns_domain: "openstacklocal"
 # Copy certificates
 ###################
 neutron_copy_certs: "{{ kolla_copy_ca_into_containers | bool or neutron_enable_tls_backend | bool }}"
+
+#####################
+# OVS cleanup
+#####################
+neutron_ovs_cleanup_marker_file: "/run/kolla/neutron_ovs_cleanup_done"

--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -1,4 +1,18 @@
 ---
+--
+- name: Ensure neutron-ovs-cleanup marker directory exists
+  become: true
+  file:
+    path: "{{ neutron_ovs_cleanup_marker_file | dirname }}"
+    state: directory
+    mode: "0755"
+
+- name: Check if neutron-ovs-cleanup has run
+  become: true
+  stat:
+    path: "{{ neutron_ovs_cleanup_marker_file }}"
+  register: ovs_cleanup_marker
+
 - name: Running neutron-ovs-cleanup container
   vars:
     service_name: "neutron-openvswitch-agent"
@@ -15,6 +29,17 @@
       OVSCLEANUP:
     name: "neutron_ovs_cleanup"
     restart_policy: no
-    remove_on_exit: true
+    remove_on_exit: false
     volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro' ] + (service.volumes[1:] | list) }}"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - not ovs_cleanup_marker.stat.exists
+
+- name: Mark neutron-ovs-cleanup complete
+  become: true
+  file:
+    path: "{{ neutron_ovs_cleanup_marker_file }}"
+    state: touch
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - not ovs_cleanup_marker.stat.exists

--- a/doc/source/reference/networking/index.rst
+++ b/doc/source/reference/networking/index.rst
@@ -14,5 +14,6 @@ Networking-SFC, QoS, and so on.
    dpdk
    neutron
    neutron-extensions
+   ovs-cleanup
    octavia
    sriov

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -1,0 +1,32 @@
+.. _ovs-cleanup:
+
+=========================
+Neutron OVS cleanup
+=========================
+
+Kolla Ansible deploys a ``neutron-ovs-cleanup`` container on hosts running the
+``neutron-openvswitch-agent`` service. The container removes stale Open
+vSwitch ports that may remain after a reboot.
+
+Operation
+---------
+
+During deployment the container runs once per host boot. After completing the
+cleanup it exits and remains stopped for manual reuse. A marker file
+``/run/kolla/neutron_ovs_cleanup_done`` is created to prevent the container
+from running again until the host is rebooted.
+
+Manual execution
+----------------
+
+The container can be started manually if needed. For example with Docker:
+
+.. code-block:: console
+
+   docker start -a neutron_ovs_cleanup
+
+To force automatic execution again remove the marker file:
+
+.. code-block:: console
+
+   sudo rm /run/kolla/neutron_ovs_cleanup_done

--- a/releasenotes/notes/ovs-cleanup-marker-20XX.yaml
+++ b/releasenotes/notes/ovs-cleanup-marker-20XX.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    The ``neutron-ovs-cleanup`` container now runs only once per host boot.
+    A marker file ``/run/kolla/neutron_ovs_cleanup_done`` prevents further
+    automatic executions until the host is rebooted. The container remains in
+    the stopped state after completion and can be started manually if
+    additional cleanup is required.


### PR DESCRIPTION
## Summary
- add marker file to prevent repeated execution of `neutron-ovs-cleanup`
- keep container after execution so it may be run manually
- document the cleanup container and how to run it

## Testing
- `pip install tox` *(fails: Tunnel connection failed)*


------
https://chatgpt.com/codex/tasks/task_e_6878df49a3808327a95291434c1e9b2d