### PR TITLE
Fix syntax error in neutron ovs-cleanup task

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -1,5 +1,4 @@
 ---
---
 - name: Ensure neutron-ovs-cleanup marker directory exists
   become: true
   file:


### PR DESCRIPTION
## Summary
- remove stray line from the neutron OVS cleanup task

## Testing
- `tox -e linters` *(fails: Could not install tox due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6878e0bffd2483279ec2d809cea6d456