### PR TITLE
Fix variable scope in neutron ovs cleanup

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -35,6 +35,9 @@
     - not ovs_cleanup_marker.stat.exists
 
 - name: Mark neutron-ovs-cleanup complete
+  vars:
+    service_name: "neutron-openvswitch-agent"
+    service: "{{ neutron_services[service_name] }}"
   become: true
   file:
     path: "{{ neutron_ovs_cleanup_marker_file }}"


### PR DESCRIPTION
## Summary
- ensure `service` variable is defined when marking `neutron-ovs-cleanup` complete

## Testing
- `pip install tox` *(fails: Could not find a version that satisfies the requirement tox)*

------
https://chatgpt.com/codex/tasks/task_e_6878e1b1ca548327a715015174e7e22d