### PR TITLE
Ensure neutron-ovs-cleanup marks completion

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -22,7 +22,7 @@
     common_options: "{{ docker_common_options }}"
     detach: False
     command: >-
-      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini'
+      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP:

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -12,9 +12,9 @@ Operation
 ---------
 
 During deployment the container runs once per host boot. After completing the
-cleanup it exits and remains stopped for manual reuse. A marker file
-``/run/kolla/neutron_ovs_cleanup_done`` is created to prevent the container
-from running again until the host is rebooted.
+cleanup it exits and remains stopped for manual reuse. The container itself
+creates a marker file ``/run/kolla/neutron_ovs_cleanup_done`` to prevent
+further automatic executions until the host is rebooted.
 
 Manual execution
 ----------------

--- a/releasenotes/notes/ovs-cleanup-container-touch-c6d196e3c1d54d0c.yaml
+++ b/releasenotes/notes/ovs-cleanup-container-touch-c6d196e3c1d54d0c.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    ``neutron-ovs-cleanup`` now creates the marker file
+    ``/run/kolla/neutron_ovs_cleanup_done`` after running. This prevents
+    accidental re-execution if the host is reconfigured while the file
+    is missing. The ansible task also touches the file as a fallback.


### PR DESCRIPTION
## Summary
- neutron-ovs-cleanup container now touches the marker file after running
- document that the container creates `/run/kolla/neutron_ovs_cleanup_done`
- add release note

## Testing
- `pip install tox` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878e6fc9bc48327a9965821c34772b8