### PR TITLE
Mount /run/kolla in neutron-ovs-cleanup

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -28,7 +28,7 @@
     name: "neutron_ovs_cleanup"
     restart_policy: no
     remove_on_exit: false
-    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro' ] + (service.volumes[1:] | list) }}"
+    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', neutron_ovs_cleanup_marker_file | dirname ~ ':' ~ neutron_ovs_cleanup_marker_file | dirname ] + (service.volumes[1:] | list) }}"
   register: ovs_cleanup_compare
   when:
     - service | service_enabled_and_mapped_to_host
@@ -49,7 +49,7 @@
     name: "neutron_ovs_cleanup"
     restart_policy: no
     remove_on_exit: false
-    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro' ] + (service.volumes[1:] | list) }}"
+    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', neutron_ovs_cleanup_marker_file | dirname ~ ':' ~ neutron_ovs_cleanup_marker_file | dirname ] + (service.volumes[1:] | list) }}"
   when:
     - service | service_enabled_and_mapped_to_host
     - ovs_cleanup_marker.stat.exists
@@ -72,7 +72,7 @@
     name: "neutron_ovs_cleanup"
     restart_policy: no
     remove_on_exit: false
-    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro' ] + (service.volumes[1:] | list) }}"
+    volumes: "{{ [ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', neutron_ovs_cleanup_marker_file | dirname ~ ':' ~ neutron_ovs_cleanup_marker_file | dirname ] + (service.volumes[1:] | list) }}"
   when:
     - service | service_enabled_and_mapped_to_host
     - not ovs_cleanup_marker.stat.exists

--- a/releasenotes/notes/fix-ovs-cleanup-run-mount-382bf7630774.yaml
+++ b/releasenotes/notes/fix-ovs-cleanup-run-mount-382bf7630774.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Mounts ``/run/kolla`` into the ``neutron-ovs-cleanup`` container so that
+    the cleanup marker file can be created successfully. The directory is
+    created on the host if needed.


### PR DESCRIPTION
## Summary
- allow neutron-ovs-cleanup container to create the marker file
- add release note describing the fix

## Testing
- `pip install tox` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878ef9661088327967f2985282ae3d1