### PR TITLE
Fix neutron-ovs-cleanup marker creation

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -4,16 +4,9 @@
   file:
     path: "{{ neutron_ovs_cleanup_marker_file | dirname }}"
     state: directory
+    owner: neutron
+    group: neutron
     mode: "0755"
-
-- name: Configure sudoers for neutron-ovs-cleanup
-  become: true
-  copy:
-    dest: /etc/sudoers.d/kolla_neutron_ovs_cleanup
-    content: "neutron ALL=(root) NOPASSWD: /usr/bin/touch {{ neutron_ovs_cleanup_marker_file }}\n"
-    owner: root
-    group: root
-    mode: "0440"
 
 - name: Check if neutron-ovs-cleanup has run
   become: true
@@ -30,7 +23,7 @@
     action: "compare_container"
     common_options: "{{ docker_common_options }}"
     command: >-
-      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && sudo /usr/bin/touch {{ neutron_ovs_cleanup_marker_file }}'
+      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP:
@@ -52,7 +45,7 @@
     action: "recreate_container"
     common_options: "{{ docker_common_options }}"
     command: >-
-      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && sudo /usr/bin/touch {{ neutron_ovs_cleanup_marker_file }}'
+      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP:
@@ -76,7 +69,7 @@
     common_options: "{{ docker_common_options }}"
     detach: False
     command: >-
-      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && sudo /usr/bin/touch {{ neutron_ovs_cleanup_marker_file }}'
+      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP:

--- a/releasenotes/notes/ovs-cleanup-root-fix-2025.yaml
+++ b/releasenotes/notes/ovs-cleanup-root-fix-2025.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes creation of the ``neutron-ovs-cleanup`` marker file when using
+    Podman by running the container command without ``sudo`` and ensuring
+    the marker directory is writable by the ``neutron`` user.


### PR DESCRIPTION
## Summary
- allow neutron user to create marker directory
- drop sudoers configuration and run touch without sudo
- document fix in release notes

## Testing
- `tox -e linters` *(fails: tox not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878f46a401c83278f1867d9df8b8d42