### PR TITLE
Update ovs cleanup marker path

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -992,4 +992,4 @@ neutron_copy_certs: "{{ kolla_copy_ca_into_containers | bool or neutron_enable_t
 #####################
 # OVS cleanup
 #####################
-neutron_ovs_cleanup_marker_file: "/run/kolla/neutron_ovs_cleanup_done"
+neutron_ovs_cleanup_marker_file: "/run/kolla/neutron_ovs_cleanup/done"

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -13,7 +13,7 @@ Operation
 
 During deployment the container runs once per host boot. After completing the
 cleanup it exits and remains stopped for manual reuse. The container itself
-creates a marker file ``/run/kolla/neutron_ovs_cleanup_done`` to prevent
+creates a marker file ``/run/kolla/neutron_ovs_cleanup/done`` to prevent
 further automatic executions until the host is rebooted. If the container
 configuration changes, the playbook recreates the container so the updated
 settings will be applied on the next run, but the container does not execute
@@ -32,4 +32,4 @@ To force automatic execution again remove the marker file:
 
 .. code-block:: console
 
-   sudo rm /run/kolla/neutron_ovs_cleanup_done
+   sudo rm /run/kolla/neutron_ovs_cleanup/done

--- a/releasenotes/notes/ovs-cleanup-marker-directory-9d8fd2a4.yaml
+++ b/releasenotes/notes/ovs-cleanup-marker-directory-9d8fd2a4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The ``neutron-ovs-cleanup`` marker file is now created in
+    ``/run/kolla/neutron_ovs_cleanup/done``. A dedicated directory is used
+    so that ownership of ``/run/kolla`` no longer needs to be changed.


### PR DESCRIPTION
## Summary
- store the neutron ovs cleanup marker in its own directory
- update docs
- add a release note

## Testing
- `tox -e linters` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f94c35d48327be81fb2206201c2f