### PR TITLE
Use /tmp for neutron-ovs-cleanup marker

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -992,4 +992,4 @@ neutron_copy_certs: "{{ kolla_copy_ca_into_containers | bool or neutron_enable_t
 #####################
 # OVS cleanup
 #####################
-neutron_ovs_cleanup_marker_file: "/run/kolla/neutron_ovs_cleanup/done"
+neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup/done"

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -13,7 +13,7 @@ Operation
 
 During deployment the container runs once per host boot. After completing the
 cleanup it exits and remains stopped for manual reuse. The container itself
-creates a marker file ``/run/kolla/neutron_ovs_cleanup/done`` to prevent
+creates a marker file ``/tmp/kolla/neutron_ovs_cleanup/done`` to prevent
 further automatic executions until the host is rebooted. If the container
 configuration changes, the playbook recreates the container so the updated
 settings will be applied on the next run, but the container does not execute
@@ -32,4 +32,4 @@ To force automatic execution again remove the marker file:
 
 .. code-block:: console
 
-   sudo rm /run/kolla/neutron_ovs_cleanup/done
+   sudo rm /tmp/kolla/neutron_ovs_cleanup/done


### PR DESCRIPTION
## Summary
- update default marker path for neutron-ovs-cleanup
- document the new path

## Testing
- `tox -e linters` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878fb5de39483278730e228c1ff092d