### PR TITLE
Fix OVS cleanup container recreation

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -41,6 +41,7 @@
     common_options: "{{ docker_common_options }}"
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
+    entrypoint: ""
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP: ""
@@ -63,6 +64,7 @@
     common_options: "{{ docker_common_options }}"
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
+    entrypoint: ""
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP: ""
@@ -87,6 +89,7 @@
     detach: False
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
+    entrypoint: ""
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP: ""


### PR DESCRIPTION
## Summary
- disable container entrypoint for neutron-ovs-cleanup

## Testing
- `tox -e linters` *(fails: H102 and flake8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879009736c08327bc0f697063148768