### PR TITLE
Remove invalid neutron OVS cleanup entrypoint

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -41,7 +41,6 @@
     common_options: "{{ docker_common_options }}"
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
-    entrypoint: ""
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP: ""
@@ -64,7 +63,6 @@
     common_options: "{{ docker_common_options }}"
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
-    entrypoint: ""
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP: ""
@@ -89,7 +87,6 @@
     detach: False
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
-    entrypoint: ""
     image: "{{ service.image }}"
     labels:
       OVSCLEANUP: ""


### PR DESCRIPTION
## Summary
- neutron: remove `entrypoint` parameter from the OVS cleanup tasks since
  `kolla_container` does not support it. This resolves the failure seen after
  PR 108 when deploying neutron OVS cleanup container.

## Testing
- `tox -e linters` *(fails: flake8 issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6879039f30248327b3fd1244a26224a3