### PR TITLE
Fix debug output interfering with container comparison

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -323,13 +323,16 @@ class ContainerWorker(ABC):
         )
 
         if verbosity >= 3 or env_debug:
-            # Preferred (Ansible ≥2.8): use the Display object if available
-            display = getattr(self.module, "_display", None)
-            if display and hasattr(display, "vvv"):
-                display.vvv(msg)
+            # Use module.debug if available to avoid polluting module output
+            if hasattr(self.module, "debug"):
+                self.module.debug(msg)
             else:
                 # Fallback for very-old Ansible or direct execution
-                print(msg)
+                display = getattr(self.module, "_display", None)
+                if display and hasattr(display, "vvv"):
+                    display.vvv(msg)
+                else:
+                    print(msg)
 
     def _as_empty_list(self, value):
         """Return [] for any "empty" representation of a list-like arg."""


### PR DESCRIPTION
## Summary
- ensure debug logs use Ansible's debug channel to avoid breaking JSON output

## Testing
- `tox -qe linters` *(fails: environment or dependency issue)*

------
https://chatgpt.com/codex/tasks/task_e_687a36a4b9dc8327a3c9fe6a67168097