### PR TITLE
Add Kolla action debug option

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -148,6 +148,9 @@ containerd_grpc_gid: 42463
 # Timeout after Docker sends SIGTERM before sending SIGKILL.
 docker_graceful_timeout: 60
 
+# Enable verbose debug logging from container actions
+kolla_action_debug: false
+
 # Common options used throughout Docker
 docker_common_options:
   auth_email: "{{ docker_registry_email }}"
@@ -156,6 +159,7 @@ docker_common_options:
   auth_username: "{{ docker_registry_username }}"
   environment:
     KOLLA_CONFIG_STRATEGY: "{{ config_strategy }}"
+    KOLLA_ACTION_DEBUG: "{{ 'true' if kolla_action_debug | bool else 'false' }}"
   restart_policy: "{{ docker_restart_policy }}"
   restart_retries: "{{ docker_restart_policy_retry }}"
   graceful_timeout: "{{ docker_graceful_timeout }}"

--- a/doc/source/user/troubleshooting.rst
+++ b/doc/source/user/troubleshooting.rst
@@ -98,3 +98,16 @@ The values ``<kolla_internal_vip_address>``, ``<kolla_external_vip_address>``
 ``<kolla_install_path>/kolla/ansible/group_vars/all.yml`` or if the default
 values are overridden, in ``/etc/kolla/globals.yml``. The value of
 ``<kibana_password>`` can be found in ``/etc/kolla/passwords.yml``.
+
+Task debugging
+--------------
+
+Kolla Ansible's container tasks can emit verbose debug output. To enable this
+logging, set ``kolla_action_debug`` to ``true`` when running Kolla Ansible:
+
+.. code-block:: console
+
+   kolla-ansible <command> -e kolla_action_debug=true
+
+This sets the ``KOLLA_ACTION_DEBUG`` environment variable for container
+actions, which can alternatively be specified directly in the environment.


### PR DESCRIPTION
## Summary
- add `kolla_action_debug` variable and propagate `KOLLA_ACTION_DEBUG`
- document how to enable action debug logs

## Testing
- `tox -e pep8`

------
https://chatgpt.com/codex/tasks/task_e_687a3893fc74832781724da2945a14b6