### PR TITLE
Add privileged flag for neutron_ovs_cleanup

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -42,6 +42,7 @@
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
     image: "{{ service.image }}"
+    privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""
     name: "neutron_ovs_cleanup"
@@ -64,6 +65,7 @@
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
     image: "{{ service.image }}"
+    privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""
     name: "neutron_ovs_cleanup"
@@ -88,6 +90,7 @@
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
     image: "{{ service.image }}"
+    privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""
     name: "neutron_ovs_cleanup"


### PR DESCRIPTION
## Summary
- allow neutron-ovs-cleanup container to run with service-defined privileges

## Testing
- `tox -e pep8`
- `tox -e linters` *(fails: UID collision in reno lint)*

------
https://chatgpt.com/codex/tasks/task_e_687a41da3f9c8327a4e821f1b4684a1e