### PR TITLE
Fix debug output regardless of ansible verbosity

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -329,8 +329,11 @@ class ContainerWorker(ABC):
             else:
                 # Fallback for very-old Ansible or direct execution
                 display = getattr(self.module, "_display", None)
-                if display and hasattr(display, "vvv"):
-                    display.vvv(msg)
+                if display:
+                    if verbosity >= 3 and hasattr(display, "vvv"):
+                        display.vvv(msg)
+                    else:
+                        display.display(msg)
                 else:
                     print(msg)
 


### PR DESCRIPTION
## Summary
- always display debug info when KOLLA_ACTION_DEBUG is set

## Testing
- `tox -e linters` *(fails: reno lint)*

------
https://chatgpt.com/codex/tasks/task_e_687a442562b08327beef245aefdb3adc