### PR TITLE
Improve container debug output

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -336,6 +336,8 @@ class ContainerWorker(ABC):
                         display.display(msg)
                 else:
                     print(msg)
+            # Save debug messages for later inspection
+            self.result.setdefault("debug", []).append(msg)
 
     def _as_empty_list(self, value):
         """Return [] for any "empty" representation of a list-like arg."""
@@ -470,6 +472,8 @@ class ContainerWorker(ABC):
                 "check_container_differs: params=" +
                 json.dumps(self.params, indent=2, sort_keys=True, default=str)
             )
+            self.result["container_info"] = container_info
+            self.result["container_params"] = self.params
 
         return differs
 

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -28,6 +28,12 @@ The container can be started manually if needed. For example with Docker:
 
    docker start -a neutron_ovs_cleanup
 
+Or with Podman:
+
+.. code-block:: console
+
+   podman start -a neutron_ovs_cleanup
+
 To force automatic execution again remove the marker file:
 
 .. code-block:: console

--- a/doc/source/user/troubleshooting.rst
+++ b/doc/source/user/troubleshooting.rst
@@ -103,11 +103,16 @@ Task debugging
 --------------
 
 Kolla Ansible's container tasks can emit verbose debug output. To enable this
-logging, set ``kolla_action_debug`` to ``true`` when running Kolla Ansible:
+logging, set ``kolla_action_debug`` to ``true`` when running Kolla Ansible and
+increase verbosity with ``-vvv``:
 
 .. code-block:: console
 
    kolla-ansible <command> -e kolla_action_debug=true
 
 This sets the ``KOLLA_ACTION_DEBUG`` environment variable for container
-actions, which can alternatively be specified directly in the environment.
+actions, which can alternatively be specified directly in the environment. The
+debug output includes the inspected container configuration and the parameters
+passed to the module. These details are also returned in the task result under
+the ``debug`` key and can be compared with ``podman inspect`` when
+troubleshooting container recreation.


### PR DESCRIPTION
## Summary
- store debug logs and container inspection details in module result
- document how to collect verbose logs and compare with podman inspect
- mention podman usage for manual neutron-ovs-cleanup execution

## Testing
- `tox -e py3` *(fails: TestResult has no addDuration method)*

------
https://chatgpt.com/codex/tasks/task_e_687a46008ac88327ab5fbb7473706259