### PR TITLE
Fix compare_container changed flag

### DIFF
--- a/ansible/library/kolla_container.py
+++ b/ansible/library/kolla_container.py
@@ -422,7 +422,13 @@ def main():
         # types. If we ever add method that will have to return some
         # meaningful data, we need to refactor all methods to return dicts.
         result = bool(getattr(cw, module.params.get('action'))())
-        module.exit_json(changed=cw.changed, result=result, **cw.result)
+        if module.params.get('action') == 'compare_container':
+            # For compare-only operations changed must mirror the actual
+            # comparison result. Returning ``changed=True`` unconditionally
+            # would make Ansible report changes even when there are none.
+            module.exit_json(changed=result, result=result, **cw.result)
+        else:
+            module.exit_json(changed=cw.changed, result=result, **cw.result)
     except Exception:
         module.fail_json(changed=True, msg=repr(traceback.format_exc()),
                          **getattr(cw, 'result', {}))


### PR DESCRIPTION
## Summary
- ensure compare_container action only marks changed when differences exist

## Testing
- `tox -e py3 -q` *(fails: AttributeError for DockerWorker.dimension_map, TemplateRuntimeError 'No filter named bool', mismatch in test_module_args)*

------
https://chatgpt.com/codex/tasks/task_e_687a62c5b3908327bcd3db23f1a21e4f