### PR TITLE
Fix compare_container action changed flag

### DIFF
--- a/ansible/library/kolla_container.py
+++ b/ansible/library/kolla_container.py
@@ -406,6 +406,12 @@ def generate_module():
     return module
 
 
+def _exit_compare(module, result, **kwargs):
+    """Exit helper ensuring changed mirrors result for compare_container."""
+    # changed must mirror result for compare_container
+    module.exit_json(changed=bool(result), result=result, **kwargs)
+
+
 def main():
     module = generate_module()
 
@@ -426,7 +432,7 @@ def main():
             # For compare-only operations changed must mirror the actual
             # comparison result. Returning ``changed=True`` unconditionally
             # would make Ansible report changes even when there are none.
-            module.exit_json(changed=result, result=result, **cw.result)
+            _exit_compare(module, result, **cw.result)
         else:
             module.exit_json(changed=cw.changed, result=result, **cw.result)
     except Exception:


### PR DESCRIPTION
## Summary
- add helper `_exit_compare` to mirror result for compare_container
- use this helper when exiting compare_container action

## Testing
- `tox -e py3 -- tests/test_kolla_container.py` *(fails: The specified regex doesn't match with anything)*

------
https://chatgpt.com/codex/tasks/task_e_687a64f35d208327a4f085a473e5a7bc