### PR TITLE
Fix compare_container output

### DIFF
--- a/ansible/library/kolla_container.py
+++ b/ansible/library/kolla_container.py
@@ -408,8 +408,8 @@ def generate_module():
 
 def _exit_compare(module, result, **kwargs):
     """Exit helper ensuring changed mirrors result for compare_container."""
-    # changed must mirror result for compare_container
-    module.exit_json(changed=bool(result), result=result, **kwargs)
+    # changed must be the inverse of result for compare_container
+    module.exit_json(changed=not bool(result), result=result, **kwargs)
 
 
 def main():


### PR DESCRIPTION
## Summary
- ensure `changed` is the opposite of `result` in compare_container

## Testing
- `tox -e py3` *(fails: AttributeError: 'DockerWorker' object has no attribute 'dimension_map')*

------
https://chatgpt.com/codex/tasks/task_e_687a67a319948327b2d010388587737f