### PR TITLE
Fix compare_container changed flag

### DIFF
--- a/ansible/library/kolla_container.py
+++ b/ansible/library/kolla_container.py
@@ -408,8 +408,8 @@ def generate_module():
 
 def _exit_compare(module, result, **kwargs):
     """Exit helper ensuring changed mirrors result for compare_container."""
-    # changed must be the inverse of result for compare_container
-    module.exit_json(changed=not bool(result), result=result, **kwargs)
+    # changed must mirror result for compare_container
+    module.exit_json(changed=bool(result), result=result, **kwargs)
 
 
 def main():

--- a/tests/test_kolla_container.py
+++ b/tests/test_kolla_container.py
@@ -218,3 +218,20 @@ def test_check_container_differs_debug():
     w.params["command"] = "/bin/new"
     assert w.check_container_differs() is True
     assert "command differs" in w.result["debug"]
+
+
+@mock.patch("kolla_container.generate_module")
+def test_compare_container_no_change(mock_generate_module):
+    module_mock = mock.MagicMock()
+    module_mock.params = {"name": "test", "action": "compare_container"}
+    mock_generate_module.return_value = module_mock
+    with mock.patch(
+        "ansible.module_utils.kolla_docker_worker.DockerWorker"
+    ) as mock_dw:
+        mock_dw.return_value.compare_container.return_value = False
+        mock_dw.return_value.changed = False
+        mock_dw.return_value.result = {}
+        kc.main()
+        mock_dw.assert_called_once_with(module_mock)
+        mock_dw.return_value.compare_container.assert_called_once_with()
+    module_mock.exit_json.assert_called_once_with(changed=False, result=False)


### PR DESCRIPTION
## Summary
- fix changed flag calculation for compare_container
- add regression test

## Testing
- `tox -e py3 -- --serial 'tests.test_kolla_container:test_compare_container_no_change'` *(fails: The specified regex doesn't match with anything)*

------
https://chatgpt.com/codex/tasks/task_e_687a69b952708327b2a12c23e70fd642