### PR TITLE
Fix compare_container changed flag

### DIFF
--- a/ansible/library/kolla_container.py
+++ b/ansible/library/kolla_container.py
@@ -432,11 +432,14 @@ def main():
         # meaningful data, we need to refactor all methods to return dicts.
         action = module.params.get('action')
         result = bool(getattr(cw, action)())
+        diff = cw.result.get('diff')
         if action == 'compare_container':
-            # ``result`` from ContainerWorker.compare_container() reflects
-            # whether the container differs from its spec.  Invert it so that
-            # ``result=True`` means the container is up-to-date.
-            _exit_compare(module, not result, **cw.result)
+            nothing_changed = not diff
+            result = nothing_changed
+            changed = not nothing_changed
+            if nothing_changed:
+                cw.result.setdefault('debug', ['no differences found'])
+            module.exit_json(changed=changed, result=result, **cw.result)
         else:
             module.exit_json(changed=cw.changed, result=result, **cw.result)
     except Exception:

--- a/releasenotes/notes/fix-compare-container-changed-flag-ebe1dabc58484e7c.yaml
+++ b/releasenotes/notes/fix-compare-container-changed-flag-ebe1dabc58484e7c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix false changed status emitted by the compare_container action when no
+    diffs are present (affects neutron-ovs-cleanup idempotency).

--- a/tests/test_kolla_container.py
+++ b/tests/test_kolla_container.py
@@ -235,3 +235,28 @@ def test_compare_container_no_change(mock_generate_module):
         mock_dw.assert_called_once_with(module_mock)
         mock_dw.return_value.compare_container.assert_called_once_with()
     module_mock.exit_json.assert_called_once_with(changed=False, result=True)
+
+
+@mock.patch("kolla_container.generate_module")
+def test_compare_container_no_change_returns_ok(mock_generate_module):
+    module_mock = mock.MagicMock()
+    module_mock.params = {"name": "test", "action": "compare_container"}
+    mock_generate_module.return_value = module_mock
+    with mock.patch(
+        "ansible.module_utils.kolla_docker_worker.DockerWorker"
+    ) as mock_dw:
+        mock_dw.return_value.compare_container.return_value = True
+        mock_dw.return_value.changed = True
+        mock_dw.return_value.result = {
+            "diff": {},
+            "debug": ["no differences found"],
+        }
+        kc.main()
+        mock_dw.assert_called_once_with(module_mock)
+        mock_dw.return_value.compare_container.assert_called_once_with()
+    module_mock.exit_json.assert_called_once_with(
+        changed=False,
+        result=True,
+        diff={},
+        debug=["no differences found"],
+    )


### PR DESCRIPTION
## Summary
- fix logic for compare_container action in kolla_container
- add regression test for compare_container no-change case
- document fix

## Testing
- `tox -e py3` *(fails: AttributeError: 'DockerWorker' object has no attribute 'dimension_map')*

------
https://chatgpt.com/codex/tasks/task_e_687a70f1082c8327bf7e3af92cae7aaa