### PR TITLE
Fix collectd ownership flapping

### DIFF
--- a/ansible/roles/collectd/tasks/config.yml
+++ b/ansible/roles/collectd/tasks/config.yml
@@ -3,8 +3,6 @@
   file:
     path: "{{ node_config_directory }}/{{ item.key }}"
     state: "directory"
-    owner: "{{ collectd_user }}"
-    group: "{{ collectd_group }}"
     mode: "0770"
   become: true
   with_dict: "{{ collectd_services | select_services_enabled_and_mapped_to_host }}"
@@ -54,8 +52,8 @@
   template:
     src: "{{ item.key }}.json.j2"
     dest: "{{ node_config_directory }}/{{ item.key }}/config.json"
-    owner: "{{ collectd_user }}"
-    group: "{{ collectd_group }}"
+    owner: "{{ collectd_uid }}"
+    group: "{{ collectd_gid }}"
     mode: "0660"
   become: true
   with_dict: "{{ collectd_services | select_services_enabled_and_mapped_to_host }}"
@@ -66,8 +64,8 @@
   template:
     src: "{{ item }}"
     dest: "{{ node_config_directory }}/collectd/collectd.conf"
-    owner: "{{ collectd_user }}"
-    group: "{{ collectd_group }}"
+    owner: "{{ collectd_uid }}"
+    group: "{{ collectd_gid }}"
     mode: "0660"
   become: true
   with_first_found:


### PR DESCRIPTION
## Summary
- stop resetting collectd config directory to root
- create files as collectd uid/gid

## Testing
- `python3 -m tox -e linters` *(fails: W503 in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687e0332c2448327822223481ddc70ac