### PR TITLE
Fix undefined ceilometer_notification in Ceilometer bootstrap facts task

### DIFF
--- a/ansible/roles/ceilometer/tasks/bootstrap_service.yml
+++ b/ansible/roles/ceilometer/tasks/bootstrap_service.yml
@@ -8,7 +8,7 @@
       - bootstrap_ceilometer
   register: bootstrap_container_facts
   run_once: true
-  delegate_to: "{{ groups[ceilometer_notification.group][0] }}"
+  delegate_to: "{{ groups['ceilometer-notification'][0] }}"
 
 - name: Running Ceilometer bootstrap container
   vars:

--- a/tests/test_ceilometer_bootstrap.py
+++ b/tests/test_ceilometer_bootstrap.py
@@ -1,0 +1,27 @@
+import os
+import yaml
+from jinja2 import Environment, StrictUndefined
+from oslotest import base
+
+
+class TestCeilometerBootstrap(base.BaseTestCase):
+    def test_delegate_to_templates(self):
+        path = os.path.join(
+            os.path.dirname(__file__),
+            '..', 'ansible', 'roles', 'ceilometer', 'tasks',
+            'bootstrap_service.yml')
+        with open(path) as f:
+            tasks = list(yaml.safe_load_all(f))
+
+        env = Environment(undefined=StrictUndefined)
+        # First task should not require ceilometer_notification variable
+        env.from_string(tasks[0]['delegate_to']).render(
+            groups={'ceilometer-notification': ['host']}
+        )
+
+        # Second task uses ceilometer_notification variable
+        env.from_string(tasks[1]['delegate_to']).render(
+            groups={'ceilometer-notification': ['host']},
+            ceilometer_notification={'group': 'ceilometer-notification'}
+        )
+


### PR DESCRIPTION
## Summary
- fix delegate_to expression in ceilometer bootstrap facts task
- add regression test covering delegate_to templates

Fixes regression introduced in PR #132 where `ceilometer_notification` was undefined for the bootstrap facts task.

## Testing
- `tox -e py3 -- tests/test_ceilometer_bootstrap.py` *(fails: The specified regex doesn't match with anything)*
- `tox -e linters` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_687e0c3a93b08327b943f9f3acc830c6