### PR TITLE
Restore ceilometer_enable_db_sync guard on bootstrap tasks

### DIFF
--- a/ansible/roles/ceilometer/defaults/main.yml
+++ b/ansible/roles/ceilometer/defaults/main.yml
@@ -198,6 +198,11 @@ ceilometer_database_type: "{{ 'gnocchi' if (enable_gnocchi | bool) else '' }}"
 ceilometer_upgrade_params: ""
 
 ####################
+# Bootstrap
+####################
+ceilometer_enable_db_sync: yes
+
+####################
 # Pushgateway
 ####################
 ceilometer_prometheus_pushgateway_host: "127.0.0.1"

--- a/ansible/roles/ceilometer/tasks/bootstrap_service.yml
+++ b/ansible/roles/ceilometer/tasks/bootstrap_service.yml
@@ -9,6 +9,7 @@
   register: bootstrap_container_facts
   run_once: true
   delegate_to: "{{ groups['ceilometer-notification'][0] }}"
+  when: ceilometer_enable_db_sync | bool
 
 - name: Running Ceilometer bootstrap container
   vars:
@@ -35,4 +36,5 @@
   run_once: True
   delegate_to: "{{ groups[ceilometer_notification.group][0] }}"
   when:
+    - ceilometer_enable_db_sync | bool
     - bootstrap_container_facts.containers['bootstrap_ceilometer'] is not defined

--- a/molecule/ceilometer_no_dbsync/molecule.yml
+++ b/molecule/ceilometer_no_dbsync/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/ceilometer_no_dbsync/playbook.yml
+++ b/molecule/ceilometer_no_dbsync/playbook.yml
@@ -1,0 +1,33 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:
+      ceilometer-notification:
+        - localhost
+    ceilometer_services:
+      ceilometer-notification:
+        image: "fake"
+        group: "ceilometer-notification"
+        volumes: []
+    ceilometer_database_type: ""
+    ceilometer_upgrade_params: ""
+    kolla_container_engine: "podman"
+    docker_common_options: {}
+    config_strategy: "COPY_ALWAYS"
+  tasks:
+    - name: Run with db sync disabled
+      include_role:
+        name: ceilometer
+        tasks_from: bootstrap_service.yml
+      vars:
+        ceilometer_enable_db_sync: no
+
+    - name: Run with db sync enabled
+      include_role:
+        name: ceilometer
+        tasks_from: bootstrap_service.yml
+      vars:
+        ceilometer_enable_db_sync: yes
+

--- a/molecule/ceilometer_no_dbsync/verify.yml
+++ b/molecule/ceilometer_no_dbsync/verify.yml
@@ -1,0 +1,16 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check bootstrap container exists once
+      command: podman ps -a --filter name=bootstrap_ceilometer --format '{{.Names}}'
+      register: container
+      changed_when: false
+      failed_when: container.stdout_lines | length != 1
+
+    - name: Check bootstrap container is not running
+      command: podman ps --filter name=bootstrap_ceilometer --format '{{.Names}}'
+      register: running
+      changed_when: false
+      failed_when: running.stdout != ''


### PR DESCRIPTION
## Problem
During previous refactors the conditional check around Ceilometer's
bootstrap tasks was removed. Even with
`ceilometer_enable_db_sync: no` the bootstrap container still runs.

## Reproduction
Set `ceilometer_enable_db_sync: no` in `globals.yml` and execute
`kolla-ansible reconfigure`. The tasks *Get Ceilometer bootstrap container
facts* and *Running Ceilometer bootstrap container* still run.

## Summary of changes
- Reintroduced `when: ceilometer_enable_db_sync | bool` guard on both
  bootstrap tasks.
- Added default `ceilometer_enable_db_sync: yes`.
- Created Molecule scenario `ceilometer_no_dbsync` verifying the tasks are
  skipped when disabled and run once when enabled.

```yaml
- name: Run with db sync disabled
  include_role:
    name: ceilometer
    tasks_from: bootstrap_service.yml
  vars:
    ceilometer_enable_db_sync: no
```

See also PRs #132–#135 for previous bootstrap fixes.

------
https://chatgpt.com/codex/tasks/task_e_687e355b3d608327800c3b0aca2d4e3c