### PR TITLE
Update doc8 env to quiet reno lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,7 @@ ignore-path = doc/source/reference/storage/external-ceph-guide.rst
 deps = {[testenv:linters]deps}
 commands =
   doc8 doc/source
-  reno lint
+  reno -q lint
   doc8 -e '.yaml' releasenotes/notes/
 
 [testenv:bashate]


### PR DESCRIPTION
## Summary
- make reno lint quiet in doc8 tox environment

## Testing
- `tox -e doc8` *(fails: UID collision)*

------
https://chatgpt.com/codex/tasks/task_e_687e4ef9403c832788bc586273840d8d