### PR TITLE
Ensure ceilometer services respect global enable flag

### DIFF
--- a/ansible/roles/ceilometer/defaults/main.yml
+++ b/ansible/roles/ceilometer/defaults/main.yml
@@ -3,7 +3,7 @@ ceilometer_services:
   ceilometer-notification:
     container_name: ceilometer_notification
     group: ceilometer-notification
-    enabled: True
+    enabled: "{{ enable_ceilometer | bool }}"
     image: "{{ ceilometer_notification_image_full }}"
     volumes: "{{ ceilometer_notification_default_volumes + ceilometer_notification_extra_volumes }}"
     dimensions: "{{ ceilometer_notification_dimensions }}"
@@ -11,7 +11,7 @@ ceilometer_services:
   ceilometer-central:
     container_name: ceilometer_central
     group: ceilometer-central
-    enabled: True
+    enabled: "{{ enable_ceilometer | bool }}"
     image: "{{ ceilometer_central_image_full }}"
     volumes: "{{ ceilometer_central_default_volumes + ceilometer_central_extra_volumes }}"
     dimensions: "{{ ceilometer_central_dimensions }}"
@@ -19,7 +19,7 @@ ceilometer_services:
   ceilometer-compute:
     container_name: ceilometer_compute
     group: ceilometer-compute
-    enabled: True
+    enabled: "{{ enable_ceilometer | bool }}"
     privileged: True
     image: "{{ ceilometer_compute_image_full }}"
     volumes: "{{ ceilometer_compute_default_volumes + ceilometer_compute_extra_volumes + lookup('vars', 'run_default_volumes_' + kolla_container_engine) }}"

--- a/releasenotes/notes/ovs-cleanup-config-change-0cfd5f1a7aed.yaml
+++ b/releasenotes/notes/ovs-cleanup-config-change-0cfd5f1a7aed.yaml
@@ -2,6 +2,7 @@
 features:
   - |
     The ``neutron-ovs-cleanup`` container is now recreated when its
-    configuration changes, even if the marker file exists. The container is not
-    executed again automatically, but the updated configuration will be used the
+    configuration changes, even if the marker file exists.
+    The container is not executed again automatically, but the updated
+    configuration will be used the
     next time it runs, such as after a host reboot.

--- a/releasenotes/notes/ovs-cleanup-marker-20XX.yaml
+++ b/releasenotes/notes/ovs-cleanup-marker-20XX.yaml
@@ -1,8 +1,0 @@
----
-features:
-  - |
-    The ``neutron-ovs-cleanup`` container now runs only once per host boot.
-    A marker file ``/run/kolla/neutron_ovs_cleanup_done`` prevents further
-    automatic executions until the host is rebooted. The container remains in
-    the stopped state after completion and can be started manually if
-    additional cleanup is required.


### PR DESCRIPTION
## Summary
- remove an old placeholder release note causing reno lint failure
- shorten a long line in a release note
- gate ceilometer services on `enable_ceilometer`

## Testing
- `tox -e linters` *(fails: bandit reported high severity issues)*

------
https://chatgpt.com/codex/tasks/task_e_687e5486b86083278119ef5a34924323