### PR TITLE
Add container verification tasks

### DIFF
--- a/ansible/roles/service-check-containers/tasks/main.yml
+++ b/ansible/roles/service-check-containers/tasks/main.yml
@@ -48,3 +48,11 @@
   loop_control:
     loop_var: outer_item
   when: (service.iterate | default(False)) | bool
+
+- name: Include verify tasks
+  include_tasks: verify.yml
+  loop: "{{ service_container_facts | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  tags:
+    - container-verify

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -1,0 +1,52 @@
+---
+# Verify that container and systemd unit exist and are active
+- name: Set unit name
+  set_fact:
+    unit_name: "kolla-{{ item.key }}-container.service"
+
+- name: Check container presence
+  become: true
+  command: >-
+    {{ kolla_container_engine }}
+    {{ 'container exists ' + item.key if kolla_container_engine == 'podman'
+       else 'container inspect ' + item.key }}
+  register: container_result
+  changed_when: false
+  failed_when: false
+
+- name: Check unit enabled
+  become: true
+  command: systemctl is-enabled --quiet {{ unit_name }}
+  register: unit_enabled
+  changed_when: false
+  failed_when: false
+
+- name: Check unit active
+  become: true
+  command: systemctl is-active --quiet {{ unit_name }}
+  register: unit_active
+  changed_when: false
+  failed_when: false
+
+- name: Record container and unit status
+  set_fact:
+    container_missing: "{{ container_result.rc != 0 }}"
+    unit_missing_or_disabled: >-
+      {{ unit_enabled.rc != 0 or unit_active.rc != 0 }}
+    needs_start: "{{ container_missing or unit_missing_or_disabled }}"
+
+- name: Notify restart when needed
+  debug:
+    msg: Notifying restart handler
+  changed_when: needs_start | bool
+  notify: "Restart {{ item.key }} container"
+
+- name: Ensure unit running when container exists
+  become: true
+  systemd:
+    name: "{{ unit_name }}"
+    state: restarted
+    enabled: true
+  when:
+    - not container_missing
+    - unit_active.rc != 0


### PR DESCRIPTION
## Summary
- add verify.yml to check podman/docker containers and systemd units
- include the new verification in service-check-containers role

## Testing
- `python3 -m tox -e ansible-lint -q` *(fails: Could not parse filters and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e5d3f29b08327b8cc04a11ea7cbdd