### PR TITLE
Fix verify loop when service_container_facts undefined

### DIFF
--- a/ansible/roles/service-check-containers/tasks/main.yml
+++ b/ansible/roles/service-check-containers/tasks/main.yml
@@ -51,7 +51,8 @@
 
 - name: Include verify tasks
   include_tasks: verify.yml
-  loop: "{{ service_container_facts | dict2items }}"
+  # Use empty dict when facts are missing to avoid failure
+  loop: "{{ (service_container_facts | default({})) | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
   tags:


### PR DESCRIPTION
## Summary
- avoid Jinja failure when service_container_facts is undefined

## Testing
- `tox -e linters` *(fails: bandit high severity issues)*
- `tox -e ansible-lint` *(fails: ansible-lint rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_687f67554f18832782040b027fbe1cd9