### PR TITLE
Fix container verify loop on podman backend

### DIFF
--- a/ansible/roles/service-check-containers/tasks/main.yml
+++ b/ansible/roles/service-check-containers/tasks/main.yml
@@ -50,9 +50,10 @@
   when: (service.iterate | default(False)) | bool
 
 - name: Include verify tasks
+  vars:
+    service: "{{ item.value }}"
   include_tasks: verify.yml
-  # Use empty dict when facts are missing to avoid failure
-  loop: "{{ (service_container_facts | default({})) | dict2items }}"
+  loop: "{{ lookup('vars', (kolla_role_name | default(project_name)) + '_services') | select_services_enabled_and_mapped_to_host | dict2items }}"
   loop_control:
     label: "{{ item.key }}"
   tags:

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -1,15 +1,16 @@
 ---
 # Verify that container and systemd unit exist and are active
-- name: Set unit name
+- name: Set container and unit names
   set_fact:
-    unit_name: "kolla-{{ item.key }}-container.service"
+    container_name: "{{ item.value.container_name | default(item.key) }}"
+    unit_name: "kolla-{{ container_name }}-container.service"
 
 - name: Check container presence
   become: true
   command: >-
     {{ kolla_container_engine }}
-    {{ 'container exists ' + item.key if kolla_container_engine == 'podman'
-       else 'container inspect ' + item.key }}
+    {{ 'container exists ' + container_name if kolla_container_engine == 'podman'
+       else 'container inspect ' + container_name }}
   register: container_result
   changed_when: false
   failed_when: false
@@ -39,7 +40,7 @@
   debug:
     msg: Notifying restart handler
   changed_when: needs_start | bool
-  notify: "Restart {{ item.key }} container"
+  notify: "Restart {{ container_name }} container"
 
 - name: Ensure unit running when container exists
   become: true


### PR DESCRIPTION
## Summary
- iterate over defined services when verifying containers
- detect container names in verify tasks

## Testing
- `tox -e ansible-lint` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f69e306e483279934404f3b775cfa