### PR TITLE
Fix unit name build for missing container names

### DIFF
--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -3,7 +3,7 @@
 - name: Set container and unit names
   set_fact:
     container_name: "{{ item.value.container_name | default(item.key) }}"
-    unit_name: "kolla-{{ container_name }}-container.service"
+    unit_name: "kolla-{{ item.value.container_name | default(item.key) }}-container.service"
 
 - name: Check container presence
   become: true


### PR DESCRIPTION
## Summary
- ensure unit_name is computed from the correct container key

## Testing
- `tox -e linters` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f6ba1e19883278b9d7c7a191a4298