### PR TITLE
Add generic restart handler for service-check role

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart container
+  listen: "^Restart .+ container$"
+  become: true
+  command: "{{ kolla_container_engine }} start {{ container_name }}"
+  when: kolla_container_engine == 'podman'


### PR DESCRIPTION
## Summary
- provide a generic handler in service-check-containers role that
  listens for any `Restart <name> container` notifications and starts the
  podman container

## Testing
- `tox -e linters` *(fails: bandit issues)*

------
https://chatgpt.com/codex/tasks/task_e_687f6e7b2f2c8327afbc8daeb551157d