### PR TITLE
Fix service-check generic restart handler

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -1,6 +1,14 @@
 ---
 - name: Restart container
-  listen: "^Restart .+ container$"
+  listen: Restart container
   become: true
-  command: "{{ kolla_container_engine }} start {{ container_name }}"
-  when: kolla_container_engine == 'podman'
+  block:
+    - name: Enable & start unit
+      command: >
+        systemctl enable --now {{ unit_name }}
+      when: unit_name is defined
+
+    - name: Start podman container if missing
+      command: >
+        podman run --detach {{ container_name }}
+      when: container_missing | default(false)

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -42,10 +42,8 @@
       {{ container_result.rc != 0 or unit_enabled.rc != 0 or unit_active.rc != 0 }}
 
 - name: Notify restart when needed
-  debug:
-    msg: Notifying restart handler
-  changed_when: needs_start | bool
-  notify: "Restart {{ container_name }} container"
+  meta: flush_handlers
+  notify: "Restart container"
 
 - name: Ensure unit running when container exists
   become: true


### PR DESCRIPTION
## Summary
- implement a single generic handler for container restarts
- update verify task to trigger this handler

## Testing
- `tox -e linters --notest` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f71010b308327a2e7975557c48eb9