### PR TITLE
Fix service-check container handler for Ansible 2.17

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -1,14 +1,14 @@
 ---
-- name: Restart container
+- name: Enable & start unit
   listen: Restart container
   become: true
-  block:
-    - name: Enable & start unit
-      command: >
-        systemctl enable --now {{ unit_name }}
-      when: unit_name is defined
+  command: >
+    systemctl enable --now {{ unit_name }}
+  when: unit_name is defined
 
-    - name: Start podman container if missing
-      command: >
-        podman run --detach {{ container_name }}
-      when: container_missing | default(false)
+- name: Start podman container if missing
+  listen: Restart container
+  become: true
+  command: >
+    podman run --detach {{ container_name }}
+  when: container_missing | default(false)


### PR DESCRIPTION
## Summary
- adjust Restart container handler to avoid using `listen` with a block

## Testing
- `tox -e linters` *(fails: Could not install packages due to an OSError: HTTPSConnectionPool(host='releases.openstack.org', port=443): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_687f731b63088327aba48d82b22321c7