### PR TITLE
Fix conditional restart in service-check-containers

### DIFF
--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -42,8 +42,13 @@
       {{ container_result.rc != 0 or unit_enabled.rc != 0 or unit_active.rc != 0 }}
 
 - name: Notify restart when needed
-  meta: flush_handlers
+  debug:
+    msg: Notifying restart handler
+  changed_when: needs_start | bool
   notify: "Restart container"
+
+- name: Flush restart handler
+  meta: flush_handlers
 
 - name: Ensure unit running when container exists
   become: true


### PR DESCRIPTION
## Summary
- only trigger the restart handler when a container or unit is missing

## Testing
- `tox -e linters` *(fails: HTTP Error 503: Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f794e7af0832782be379a22e38004