### PR TITLE
Fix container recreation in service-check role

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Recreate container when missing
+  listen: Restart container
+  when: container_missing | bool
+  import_tasks: recreate_container.yml
+  notify: Restart unit as fallback
+
 - name: Attempt runtime restart first
   listen: Restart container
   become: true

--- a/ansible/roles/service-check-containers/tasks/recreate_container.yml
+++ b/ansible/roles/service-check-containers/tasks/recreate_container.yml
@@ -1,0 +1,22 @@
+---
+- name: Recreate container
+  become: true
+  kolla_container:
+    action: "recreate_container"
+    common_options: "{{ docker_common_options }}"
+    name: "{{ container_name }}"
+    image: "{{ service.image | default(omit) }}"
+    volumes: "{{ service.volumes | default(omit) }}"
+    dimensions: "{{ service.dimensions | default(omit) }}"
+    tmpfs: "{{ service.tmpfs | default(omit) }}"
+    volumes_from: "{{ service.volumes_from | default(omit) }}"
+    privileged: "{{ service.privileged | default(omit) }}"
+    cap_add: "{{ service.cap_add | default(omit) }}"
+    environment: "{{ service.environment | default(omit) }}"
+    healthcheck: "{{ service.healthcheck | default(omit) }}"
+    ipc_mode: "{{ service.ipc_mode | default(omit) }}"
+    pid_mode: "{{ service.pid_mode | default(omit) }}"
+    security_opt: "{{ service.security_opt | default(omit) }}"
+    labels: "{{ service.labels | default(omit) }}"
+    command: "{{ service.command | default(omit) }}"
+    cgroupns_mode: "{{ service.cgroupns_mode | default(omit) }}"

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -41,6 +41,11 @@
     needs_start: >-
       {{ container_result.rc != 0 or unit_enabled.rc != 0 or unit_active.rc != 0 }}
 
+- name: Notify recreate handler when needed
+  when: container_missing | bool and not unit_missing_or_disabled
+  meta: clear_host_errors
+  notify: "Recreate container when missing"
+
 - name: Notify restart when needed
   debug:
     msg: Notifying restart handler

--- a/docs/changelog
+++ b/docs/changelog
@@ -1,0 +1,1 @@
+- Fix container recreation when unit exists


### PR DESCRIPTION
## Summary
- ensure missing containers are recreated
- add handler to import recreate tasks
- document change in docs/changelog

## Testing
- `tox -e linters` *(fails: HTTP Error 503)*

------
https://chatgpt.com/codex/tasks/task_e_687f7c805d80832782d204d49e9a8129