### PR TITLE
Fix handler invocation when container missing

### DIFF
--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -23,9 +23,13 @@
 - name: Check unit enabled
   become: true
   command: systemctl is-enabled --quiet {{ unit_name }}
-  register: unit_enabled
+  register: unit_enabled_res
   changed_when: false
   failed_when: false
+
+- name: Set unit enabled fact
+  set_fact:
+    unit_enabled: "{{ unit_enabled_res.rc == 0 }}"
 
 - name: Check unit active
   become: true
@@ -37,9 +41,9 @@
 - name: Record container and unit status
   set_fact:
     container_missing: "{{ container_result.rc != 0 }}"
-    unit_missing_or_disabled: "{{ unit_enabled.rc != 0 or unit_active.rc != 0 }}"
+    unit_missing_or_disabled: "{{ not unit_enabled }}"
     needs_start: >-
-      {{ container_result.rc != 0 or unit_enabled.rc != 0 or unit_active.rc != 0 }}
+      {{ container_result.rc != 0 or not unit_enabled or unit_active.rc != 0 }}
 
 - name: Notify recreate handler when needed
   when: container_missing | bool and not unit_missing_or_disabled

--- a/docs/changelog
+++ b/docs/changelog
@@ -1,1 +1,2 @@
 - Fix container recreation when unit exists
+- Handle enabled but inactive units when recreating containers


### PR DESCRIPTION
## Summary
- service-check-containers: fix logic for triggering recreate
- document the fix

## Testing
- `tox -e linters` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f808a5044832795197e42872985e9