### PR TITLE
Fix container recreate handler trigger

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -1,8 +1,11 @@
 ---
+- name: Recreate container
+  import_tasks: recreate.yml
+
 - name: Recreate container when missing
   listen: Restart container
   when: container_missing | bool
-  import_tasks: recreate_container.yml
+  import_tasks: recreate.yml
   notify: Restart unit as fallback
 
 - name: Attempt runtime restart first

--- a/ansible/roles/service-check-containers/tasks/recreate.yml
+++ b/ansible/roles/service-check-containers/tasks/recreate.yml
@@ -1,0 +1,22 @@
+---
+- name: Recreate container
+  become: true
+  kolla_container:
+    action: recreate_container
+    common_options: "{{ docker_common_options }}"
+    name: "{{ container_name }}"
+    image: "{{ service.image | default(omit) }}"
+    volumes: "{{ service.volumes | default(omit) }}"
+    dimensions: "{{ service.dimensions | default(omit) }}"
+    tmpfs: "{{ service.tmpfs | default(omit) }}"
+    volumes_from: "{{ service.volumes_from | default(omit) }}"
+    privileged: "{{ service.privileged | default(omit) }}"
+    cap_add: "{{ service.cap_add | default(omit) }}"
+    environment: "{{ service.environment | default(omit) }}"
+    healthcheck: "{{ service.healthcheck | default(omit) }}"
+    ipc_mode: "{{ service.ipc_mode | default(omit) }}"
+    pid_mode: "{{ service.pid_mode | default(omit) }}"
+    security_opt: "{{ service.security_opt | default(omit) }}"
+    labels: "{{ service.labels | default(omit) }}"
+    command: "{{ service.command | default(omit) }}"
+    cgroupns_mode: "{{ service.cgroupns_mode | default(omit) }}"

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -45,10 +45,15 @@
     needs_start: >-
       {{ container_result.rc != 0 or not unit_enabled or unit_active.rc != 0 }}
 
-- name: Notify recreate handler when needed
-  when: container_missing | bool and not unit_missing_or_disabled
+- name: Clear host error state
   meta: clear_host_errors
-  notify: "Recreate container when missing"
+
+- name: Notify recreate handler when needed
+  debug:
+    msg: "Scheduling container recreation"
+  changed_when: true
+  when: container_missing | bool and unit_enabled | bool
+  notify: Recreate container
 
 - name: Notify restart when needed
   debug:

--- a/releasenotes/notes/fix-missing-container-recreation-3a228a2e.yaml
+++ b/releasenotes/notes/fix-missing-container-recreation-3a228a2e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Missing containers are now recreated again when the service unit is enabled.
+    Fixes #1234.


### PR DESCRIPTION
## Summary
- ensure we clear host errors and notify a new `Recreate container` handler
- add the new handler and task to recreate containers
- document that missing containers are recreated again

Fixes #1234

## Testing
- `tox -e linters` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f838d5cf08327848cec7de7dd1dc8