### PR TITLE
Fix missing container recreation mounts

### DIFF
--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -46,6 +46,10 @@
     needs_start: >-
       {{ container_result.rc != 0 or not unit_enabled or unit_active.rc != 0 }}
 
+- name: Init service fact for handlers
+  set_fact:
+    service: "{{ container_spec }}"
+
 - name: Clear host error state
   meta: clear_host_errors
 


### PR DESCRIPTION
## Summary
- pass the container spec as `service` fact before calling handlers

## Testing
- `tox -e ansible-lint` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f8c713e2083279c8b9c80fa90b112