### PR TITLE
Fix ceilometer group checks

### DIFF
--- a/ansible/roles/ceilometer/tasks/bootstrap_service.yml
+++ b/ansible/roles/ceilometer/tasks/bootstrap_service.yml
@@ -8,8 +8,10 @@
       - bootstrap_ceilometer
   register: bootstrap_container_facts
   run_once: true
-  delegate_to: "{{ groups['ceilometer-notification'][0] }}"
-  when: ceilometer_enable_db_sync | bool
+  delegate_to: "{{ (groups['ceilometer-notification'] | default([])) | first }}"
+  when:
+    - ceilometer_enable_db_sync | bool
+    - groups['ceilometer-notification'] is defined
 
 - name: Running Ceilometer bootstrap container
   vars:
@@ -34,7 +36,8 @@
     restart_policy: oneshot
     volumes: "{{ ceilometer_notification.volumes | reject('equalto', '') | list }}"
   run_once: True
-  delegate_to: "{{ groups[ceilometer_notification.group][0] }}"
+  delegate_to: "{{ (groups[ceilometer_notification.group] | default([])) | first }}"
   when:
     - ceilometer_enable_db_sync | bool
     - bootstrap_container_facts.containers['bootstrap_ceilometer'] is not defined
+    - ceilometer_notification.group in groups

--- a/ansible/roles/ceilometer/tasks/config.yml
+++ b/ansible/roles/ceilometer/tasks/config.yml
@@ -80,7 +80,7 @@
   become: true
   when:
     - should_copy_dynamic_pollster_definitions
-    - inventory_hostname in groups['ceilometer-central']
+    - inventory_hostname in (groups['ceilometer-central'] | default([]))
 
 - name: Copying dynamic pollsters definitions
   copy:
@@ -90,7 +90,7 @@
   become: true
   when:
     - should_copy_dynamic_pollster_definitions
-    - inventory_hostname in groups['ceilometer-central']
+    - inventory_hostname in (groups['ceilometer-central'] | default([]))
 
 - name: Check if custom polling.yaml exists
   stat:


### PR DESCRIPTION
## Summary
- guard references to ceilometer groups
- avoid crashes on hosts without ceilometer groups

## Testing
- `tox -e linters` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f8ee060988327bc8c0322024cf79c