### PR TITLE
Fix health-check drift recreation

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -2,9 +2,10 @@
 - name: Recreate container
   import_tasks: recreate.yml
 
-- name: Recreate container when missing
+- name: Recreate container when missing or drifted
   listen: Restart container
-  when: container_missing | bool
+  when:
+    - container_missing | bool or container_needs_recreate | bool
   import_tasks: recreate.yml
   notify: Restart unit as fallback
 
@@ -15,6 +16,7 @@
   register: runtime_restart
   failed_when: false
   changed_when: runtime_restart.rc == 0
+  when: not container_needs_recreate | bool
 
 - name: Ensure unit enabled
   listen: Restart container
@@ -22,7 +24,9 @@
   systemd:
     name: "{{ unit_name }}"
     enabled: true
-  when: runtime_restart.rc != 0
+  when:
+    - not container_needs_recreate | bool
+    - runtime_restart.rc != 0
 
 - name: Restart unit as fallback
   listen: Restart container
@@ -30,4 +34,6 @@
   systemd:
     name: "{{ unit_name }}"
     state: restarted
-  when: runtime_restart.rc != 0
+  when:
+    - not container_needs_recreate | bool
+    - runtime_restart.rc != 0

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -4,12 +4,17 @@
   set_fact:
     container_missing: false
     unit_missing_or_disabled: false
+    container_needs_recreate: false
   when: container_missing is not defined or unit_missing_or_disabled is not defined
 - name: Set container and unit names
   set_fact:
     container_name: "{{ item.value.container_name | default(item.key) }}"
     unit_name: "kolla-{{ item.value.container_name | default(item.key) }}-container.service"
     container_spec: "{{ item.value }}"
+
+- name: Set desired healthcheck test
+  set_fact:
+    desired_healthcheck_test: "{{ container_spec.healthcheck.test | default([]) }}"
 
 - name: Check container presence
   become: true
@@ -20,6 +25,21 @@
   register: container_result
   changed_when: false
   failed_when: false
+
+- name: Inspect container
+  become: true
+  kolla_container_facts:
+    action: get_containers
+    container_engine: "{{ kolla_container_engine }}"
+    name:
+      - "{{ container_name }}"
+  register: inspect_result
+  when: container_result.rc == 0
+
+- name: Set container_inspect fact
+  set_fact:
+    container_inspect: "{{ inspect_result.containers[container_name] }}"
+  when: inspect_result is defined
 
 - name: Check unit enabled
   become: true
@@ -46,6 +66,14 @@
     needs_start: >-
       {{ container_result.rc != 0 or not unit_enabled or unit_active.rc != 0 }}
 
+- name: Detect health-check drift
+  set_fact:
+    container_needs_recreate: true
+  when:
+    - not container_missing
+    - (container_inspect.Config.Healthcheck.Test | default([]) | to_json)
+      != (desired_healthcheck_test | to_json)
+
 - name: Init service fact for handlers
   set_fact:
     service: "{{ container_spec }}"
@@ -57,14 +85,15 @@
   debug:
     msg: "Scheduling container recreation"
   changed_when: true
-  when: container_missing | bool and unit_enabled | bool
+  when: (container_missing | bool or container_needs_recreate | bool) and unit_enabled | bool
   notify: Recreate container
 
 - name: Notify restart when needed
   debug:
     msg: Notifying restart handler
-  changed_when: needs_start | bool
+  changed_when: needs_start | bool and not container_needs_recreate | bool
   notify: "Restart container"
+  when: not container_needs_recreate | bool
 
 - name: Flush restart handler
   meta: flush_handlers

--- a/molecule/healthcheck_update/molecule.yml
+++ b/molecule/healthcheck_update/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/healthcheck_update/playbook.yml
+++ b/molecule/healthcheck_update/playbook.yml
@@ -1,0 +1,36 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:
+      testgroup:
+        - localhost
+    project_name: testhc
+    testhc_services:
+      test:
+        container_name: test_hc
+        group: testgroup
+        enabled: true
+        image: docker.io/library/busybox:latest
+        volumes: []
+        healthcheck:
+          test: "{{ my_healthcheck_test }}"
+          interval: 1
+          retries: 1
+          start_period: 0
+          timeout: 1
+    kolla_container_engine: podman
+    docker_common_options: {}
+  tasks:
+    - name: Run role with initial healthcheck
+      vars:
+        my_healthcheck_test: ["CMD-SHELL", "echo old"]
+      include_role:
+        name: service-check-containers
+
+    - name: Run role after healthcheck update
+      vars:
+        my_healthcheck_test: ["CMD-SHELL", "echo new"]
+      include_role:
+        name: service-check-containers

--- a/molecule/healthcheck_update/verify.yml
+++ b/molecule/healthcheck_update/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check healthcheck updated
+      command: podman container inspect test_hc --format '{{json .Config.Healthcheck.Test}}'
+      register: result
+      changed_when: false
+    - name: Assert new healthcheck
+      assert:
+        that:
+          - result.stdout == '["CMD-SHELL","echo new"]'


### PR DESCRIPTION
## Summary
- detect healthcheck mismatches in service-check-containers verify tasks
- recreate containers when healthcheck drift is detected
- avoid runtime restart when drift requires recreation
- add molecule scenario testing healthcheck update

## Testing
- `tox -e linters` *(fails: HTTP Error 503 Service Unavailable)*
- `tox -e py3` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f9663c5ac8327acce6b1cc134f54a