### PR TITLE
Fix container-inspect failure in service-check

### DIFF
--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -38,8 +38,8 @@
 
 - name: Set container_inspect fact
   set_fact:
-    container_inspect: "{{ inspect_result.containers[container_name] }}"
-  when: inspect_result is defined
+    container_inspect: >-
+      {{ (inspect_result.containers | default({})).get(container_name, {}) }}
 
 - name: Check unit enabled
   become: true


### PR DESCRIPTION
## Summary
- avoid failing when a container does not exist

## Testing
- `tox -e linters -- ansible/roles/service-check-containers/tasks/verify.yml` *(fails: HTTP Error 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f9d2959cc8327a7a25500891f8d41