### PR TITLE
Fix container config drift detection

### DIFF
--- a/ansible/library/kolla_container.py
+++ b/ansible/library/kolla_container.py
@@ -434,10 +434,9 @@ def main():
         result = bool(getattr(cw, action)())
         diff = cw.result.get('diff')
         if action == 'compare_container':
-            nothing_changed = not diff
-            result = nothing_changed
-            changed = not nothing_changed
-            if nothing_changed:
+            changed = cw.changed
+            result = not changed
+            if not changed and not diff:
                 cw.result.setdefault('debug', ['no differences found'])
             module.exit_json(changed=changed, result=result, **cw.result)
         else:


### PR DESCRIPTION
## Summary
- detect container config drift using worker state

## Testing
- `tox -e py3 -q` *(fails: TestResult has no addDuration method)*

------
https://chatgpt.com/codex/tasks/task_e_6880a80eed1083279a1ba00f9efd54f7