### PR TITLE
Sync optional api_paste.ini

### DIFF
--- a/ansible/roles/cinder/tasks/config.yml
+++ b/ansible/roles/cinder/tasks/config.yml
@@ -122,6 +122,28 @@
     - cinder_policy_file is defined
   with_dict: "{{ cinder_services | select_services_enabled_and_mapped_to_host }}"
 
+- name: Checking whether api-paste.ini file exists
+  vars:
+    service: "{{ cinder_services['cinder-api'] }}"
+  stat:
+    path: "{{ node_custom_config }}/cinder/api-paste.ini"
+  delegate_to: localhost
+  run_once: True
+  register: check_cinder_api_paste_ini
+  when: service | service_enabled_and_mapped_to_host
+
+- name: Copying over api-paste.ini
+  vars:
+    service: "{{ cinder_services['cinder-api'] }}"
+  template:
+    src: "{{ node_custom_config }}/cinder/api-paste.ini"
+    dest: "{{ node_config_directory }}/cinder-api/api-paste.ini"
+    mode: "0660"
+  become: true
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - check_cinder_api_paste_ini.stat.exists
+
 - name: Copying over nfs_shares files for cinder_volume
   vars:
     service: "{{ cinder_services['cinder-volume'] }}"

--- a/ansible/roles/cinder/templates/cinder-api.json.j2
+++ b/ansible/roles/cinder/templates/cinder-api.json.j2
@@ -27,7 +27,14 @@
             "dest": "/etc/cinder/{{ cinder_policy_file }}",
             "owner": "cinder",
             "perm": "0600"
-        }{% endif %}{% if cinder_enable_tls_backend | bool %},
+        }{% endif %},
+        {
+            "source": "{{ container_config_directory }}/api-paste.ini",
+            "dest": "/etc/cinder/api-paste.ini",
+            "owner": "cinder",
+            "perm": "0600",
+            "optional": true
+        }{% if cinder_enable_tls_backend | bool %},
         {
             "source": "{{ container_config_directory }}/cinder-cert.pem",
             "dest": "/etc/cinder/certs/cinder-cert.pem",

--- a/ansible/roles/glance/tasks/config.yml
+++ b/ansible/roles/glance/tasks/config.yml
@@ -123,6 +123,28 @@
     - glance_policy_file is defined
     - service | service_enabled_and_mapped_to_host
 
+- name: Checking whether api-paste.ini file exists
+  vars:
+    service: "{{ glance_services['glance-api'] }}"
+  stat:
+    path: "{{ node_custom_config }}/glance/api-paste.ini"
+  delegate_to: localhost
+  run_once: True
+  register: check_glance_api_paste_ini
+  when: service | service_enabled_and_mapped_to_host
+
+- name: Copying over api-paste.ini
+  vars:
+    service: "{{ glance_services['glance-api'] }}"
+  template:
+    src: "{{ node_custom_config }}/glance/api-paste.ini"
+    dest: "{{ node_config_directory }}/glance-api/api-paste.ini"
+    mode: "0660"
+  become: true
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - check_glance_api_paste_ini.stat.exists
+
 - name: Copying over glance-haproxy-tls.cfg
   vars:
     service: "{{ glance_services['glance-tls-proxy'] }}"

--- a/ansible/roles/glance/templates/glance-api.json.j2
+++ b/ansible/roles/glance/templates/glance-api.json.j2
@@ -36,7 +36,14 @@
             "dest": "/etc/glance/property-protections-rules.conf",
             "owner": "glance",
             "perm": "0600"
-        }{% endif %}{% if glance_copy_certs | bool %},
+        }{% endif %},
+        {
+            "source": "{{ container_config_directory }}/api-paste.ini",
+            "dest": "/etc/glance/api-paste.ini",
+            "owner": "glance",
+            "perm": "0600",
+            "optional": true
+        }{% if glance_copy_certs | bool %},
         {
             "source": "{{ container_config_directory }}/ca-certificates",
             "dest": "/var/lib/kolla/share/ca-certificates",

--- a/ansible/roles/heat/tasks/config.yml
+++ b/ansible/roles/heat/tasks/config.yml
@@ -65,6 +65,28 @@
     - heat_policy_file is defined
   with_dict: "{{ heat_services | select_services_enabled_and_mapped_to_host }}"
 
+- name: Checking whether api-paste.ini file exists
+  vars:
+    service: "{{ heat_services['heat-api'] }}"
+  stat:
+    path: "{{ node_custom_config }}/heat/api-paste.ini"
+  delegate_to: localhost
+  run_once: True
+  register: check_heat_api_paste_ini
+  when: service | service_enabled_and_mapped_to_host
+
+- name: Copying over api-paste.ini
+  vars:
+    service: "{{ heat_services['heat-api'] }}"
+  template:
+    src: "{{ node_custom_config }}/heat/api-paste.ini"
+    dest: "{{ node_config_directory }}/heat-api/api-paste.ini"
+    mode: "0660"
+  become: true
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - check_heat_api_paste_ini.stat.exists
+
 - name: Copying over heat-api wsgi config
   vars:
     service: "{{ heat_services['heat-api'] }}"

--- a/ansible/roles/heat/templates/heat-api-cfn.json.j2
+++ b/ansible/roles/heat/templates/heat-api-cfn.json.j2
@@ -19,7 +19,14 @@
             "dest": "/etc/heat/{{ heat_policy_file }}",
             "owner": "heat",
             "perm": "0600"
-        }{% endif %}{% if heat_enable_tls_backend | bool %},
+        }{% endif %},
+        {
+            "source": "{{ container_config_directory }}/api-paste.ini",
+            "dest": "/etc/heat/api-paste.ini",
+            "owner": "heat",
+            "perm": "0600",
+            "optional": true
+        }{% if heat_enable_tls_backend | bool %},
         {
             "source": "{{ container_config_directory }}/heat-cert.pem",
             "dest": "/etc/heat/certs/heat-cert.pem",

--- a/ansible/roles/heat/templates/heat-api.json.j2
+++ b/ansible/roles/heat/templates/heat-api.json.j2
@@ -19,7 +19,14 @@
             "dest": "/etc/heat/{{ heat_policy_file }}",
             "owner": "heat",
             "perm": "0600"
-        }{% endif %}{% if heat_enable_tls_backend | bool %},
+        }{% endif %},
+        {
+            "source": "{{ container_config_directory }}/api-paste.ini",
+            "dest": "/etc/heat/api-paste.ini",
+            "owner": "heat",
+            "perm": "0600",
+            "optional": true
+        }{% if heat_enable_tls_backend | bool %},
         {
             "source": "{{ container_config_directory }}/heat-cert.pem",
             "dest": "/etc/heat/certs/heat-cert.pem",

--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -76,6 +76,28 @@
     - neutron_policy_file is defined
   with_dict: "{{ neutron_services | select_services_enabled_and_mapped_to_host }}"
 
+- name: Checking whether api-paste.ini file exists
+  vars:
+    service: "{{ neutron_services['neutron-server'] }}"
+  stat:
+    path: "{{ node_custom_config }}/neutron/api-paste.ini"
+  delegate_to: localhost
+  run_once: True
+  register: check_neutron_api_paste_ini
+  when: service | service_enabled_and_mapped_to_host
+
+- name: Copying over api-paste.ini
+  vars:
+    service: "{{ neutron_services['neutron-server'] }}"
+  template:
+    src: "{{ node_custom_config }}/neutron/api-paste.ini"
+    dest: "{{ node_config_directory }}/neutron-server/api-paste.ini"
+    mode: "0660"
+  become: true
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - check_neutron_api_paste_ini.stat.exists
+
 - name: Copying over config.json files for services
   become: true
   template:

--- a/ansible/roles/neutron/templates/neutron-server.json.j2
+++ b/ansible/roles/neutron/templates/neutron-server.json.j2
@@ -34,7 +34,14 @@
             "dest": "/etc/neutron/{{ neutron_policy_file }}",
             "owner": "neutron",
             "perm": "0600"
-        },{% endif %}
+        },{% endif %},
+        {
+            "source": "{{ container_config_directory }}/api-paste.ini",
+            "dest": "/etc/neutron/api-paste.ini",
+            "owner": "neutron",
+            "perm": "0600",
+            "optional": true
+        },
 {% if neutron_plugin_agent in ['vmware_nsxv', 'vmware_nsxv3', 'vmware_nsxp', 'vmware_dvs'] -%}
         {
             "source": "{{ container_config_directory }}/nsx.ini",

--- a/ansible/roles/nova/tasks/config.yml
+++ b/ansible/roles/nova/tasks/config.yml
@@ -79,6 +79,28 @@
     - item.key in nova_services_require_policy_json
   with_dict: "{{ nova_services | select_services_enabled_and_mapped_to_host }}"
 
+- name: Checking whether api-paste.ini file exists
+  vars:
+    service: "{{ nova_services['nova-api'] }}"
+  stat:
+    path: "{{ node_custom_config }}/nova/api-paste.ini"
+  delegate_to: localhost
+  run_once: True
+  register: check_nova_api_paste_ini
+  when: service | service_enabled_and_mapped_to_host
+
+- name: Copying over api-paste.ini
+  vars:
+    service: "{{ nova_services['nova-api'] }}"
+  template:
+    src: "{{ node_custom_config }}/nova/api-paste.ini"
+    dest: "{{ node_config_directory }}/nova-api/api-paste.ini"
+    mode: "0660"
+  become: true
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - check_nova_api_paste_ini.stat.exists
+
 - name: Copying over nova-api-wsgi.conf
   vars:
     service: "{{ nova_services['nova-api'] }}"

--- a/ansible/roles/nova/templates/nova-api.json.j2
+++ b/ansible/roles/nova/templates/nova-api.json.j2
@@ -27,7 +27,14 @@
             "dest": "/etc/nova/{{ nova_policy_file }}",
             "owner": "nova",
             "perm": "0600"
-        }{% endif %}{% if nova_enable_tls_backend | bool %},
+        }{% endif %},
+        {
+            "source": "{{ container_config_directory }}/api-paste.ini",
+            "dest": "/etc/nova/api-paste.ini",
+            "owner": "nova",
+            "perm": "0600",
+            "optional": true
+        }{% if nova_enable_tls_backend | bool %},
         {
             "source": "{{ container_config_directory }}/nova-cert.pem",
             "dest": "/etc/nova/certs/nova-cert.pem",

--- a/ansible/roles/nova/templates/nova-metadata.json.j2
+++ b/ansible/roles/nova/templates/nova-metadata.json.j2
@@ -27,7 +27,14 @@
             "dest": "/etc/nova/{{ nova_policy_file }}",
             "owner": "nova",
             "perm": "0600"
-        }{% endif %}{% if nova_enable_tls_backend | bool %},
+        }{% endif %},
+        {
+            "source": "{{ container_config_directory }}/api-paste.ini",
+            "dest": "/etc/nova/api-paste.ini",
+            "owner": "nova",
+            "perm": "0600",
+            "optional": true
+        }{% if nova_enable_tls_backend | bool %},
         {
             "source": "{{ container_config_directory }}/nova-cert.pem",
             "dest": "/etc/nova/certs/nova-cert.pem",

--- a/releasenotes/notes/fix-missing-container-recreation-3a228a2e.yaml
+++ b/releasenotes/notes/fix-missing-container-recreation-3a228a2e.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Missing containers are now recreated again when the service unit is enabled.
-    Fixes #1234.
+    Missing containers are now recreated again when the service unit is
+    enabled. Fixes #1234.


### PR DESCRIPTION
## Summary
- copy api-paste.ini from /etc/kolla/config if present
- include api-paste.ini in container configs

## Testing
- `tox -e linters` *(fails: bandit security checks)*

------
https://chatgpt.com/codex/tasks/task_e_6880ad354e508327b6fc6c342acd6639