### PR TITLE
Ensure linuxbridge config dir

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -9,6 +9,17 @@
     mode: "0770"
   with_dict: "{{ neutron_services | select_services_enabled_and_mapped_to_host }}"
 
+- name: Ensuring neutron-linuxbridge-agent config directory exists
+  become: true
+  file:
+    path: "{{ node_config_directory }}/neutron-linuxbridge-agent"
+    state: "directory"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0770"
+  when:
+    - neutron_plugin_agent == 'linuxbridge'
+
 - name: Ensuring neutron-ovs-cleanup config directory exists
   become: true
   vars:


### PR DESCRIPTION
## Summary
- guarantee neutron-linuxbridge-agent directory exists before copying configs

## Testing
- `tox -e linters` *(fails: bandit issues)*

------
https://chatgpt.com/codex/tasks/task_e_68876d4f6a908327ae03ab30fccb76b8