### PR TITLE
Ensure linuxbridge custom config dir

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -9,16 +9,18 @@
     mode: "0770"
   with_dict: "{{ neutron_services | select_services_enabled_and_mapped_to_host }}"
 
-- name: Ensuring neutron-linuxbridge-agent config directory exists
+- name: Ensure linuxbridge agent config dir exists
   become: true
   file:
-    path: "{{ node_config_directory }}/neutron-linuxbridge-agent"
-    state: "directory"
-    owner: "{{ config_owner_user }}"
-    group: "{{ config_owner_group }}"
+    path: "{{ node_custom_config }}/neutron-linuxbridge-agent"
+    state: directory
+    owner: root
+    group: root
     mode: "0770"
   when:
     - neutron_plugin_agent == 'linuxbridge'
+    - service_enabled_and_mapped_to_host('neutron-linuxbridge-agent')
+
 
 - name: Ensuring neutron-ovs-cleanup config directory exists
   become: true


### PR DESCRIPTION
## Summary
- ensure the custom config dir for the linuxbridge agent exists
- remove duplicate directory creation from config.yml

## Testing
- `tox -e linters` *(fails: bandit reported issues)*

------
https://chatgpt.com/codex/tasks/task_e_68876fa65d9083279c36b4c7fa96d2d0