### PR TITLE
Fix linuxbridge config directory check

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -228,7 +228,7 @@
   loop: "{{ neutron_services | dict2items }}"
   when:
     - item.key == 'neutron-linuxbridge-agent'
-    - item.value.enabled | bool
+    - not (item.value.enabled | bool)
     - item.value.host_in_groups | default(false) | bool
 
 - name: Copying over linuxbridge_agent.ini


### PR DESCRIPTION
## Summary
- handle linuxbridge disabled case gracefully

## Testing
- `tox -e linters` *(fails: bandit warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68877eba182c83279d744564844eac6b