### PR TITLE
Fix linuxbridge agent config directory

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -231,6 +231,19 @@
     - not (item.value.enabled | bool)
     - item.value.host_in_groups | default(false) | bool
 
+- name: Ensuring neutron-linuxbridge-agent config directory exists
+  become: true
+  vars:
+    service_name: "neutron-linuxbridge-agent"
+    service: "{{ neutron_services[service_name] }}"
+  file:
+    path: "{{ node_config_directory }}/{{ service_name }}"
+    state: "directory"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0770"
+  when: service | service_enabled_and_mapped_to_host
+
 - name: Copying over linuxbridge_agent.ini
   become: true
   vars:


### PR DESCRIPTION
## Summary
- ensure neutron-linuxbridge-agent directory exists in node_config

## Testing
- `tox -e linters` *(fails: bandit found issues)*

------
https://chatgpt.com/codex/tasks/task_e_6887862b31f88327846a46760f58249a