### PR TITLE
Fix sriov agent config directory

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -273,6 +273,32 @@
   when: service | service_enabled_and_mapped_to_host
 
 
+- name: Ensure sriov agent config dir exists
+  file:
+    path: "{{ node_custom_config }}/{{ item.key }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0770"
+  loop: "{{ neutron_services | dict2items }}"
+  when:
+    - item.key == 'neutron-sriov-agent'
+    - not (item.value.enabled | bool)
+    - item.value.host_in_groups | default(false) | bool
+
+- name: Ensuring neutron-sriov-agent config directory exists
+  become: true
+  vars:
+    service_name: "neutron-sriov-agent"
+    service: "{{ neutron_services[service_name] }}"
+  file:
+    path: "{{ node_config_directory }}/{{ service_name }}"
+    state: "directory"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0770"
+  when: service | service_enabled_and_mapped_to_host
+
 - name: Copying over sriov_agent.ini
   become: true
   vars:


### PR DESCRIPTION
## Summary
- ensure sriov agent config dir exists before copying sriov_agent.ini

## Testing
- `tox -e linters` *(fails: bandit issues)*

------
https://chatgpt.com/codex/tasks/task_e_68878e60e6fc83279cc48db735156895