### PR TITLE
Fix eswitchd config tasks

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -353,6 +353,32 @@
     mode: "0660"
   when: service | service_enabled_and_mapped_to_host
 
+- name: Ensure eswitchd config dir exists
+  file:
+    path: "{{ node_custom_config }}/{{ item.key }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0770"
+  loop: "{{ neutron_services | dict2items }}"
+  when:
+    - item.key == 'neutron-eswitchd'
+    - not (item.value.enabled | bool)
+    - item.value.host_in_groups | default(false) | bool
+
+- name: Ensuring neutron-eswitchd config directory exists
+  become: true
+  vars:
+    service_name: "neutron-eswitchd"
+    service: "{{ neutron_services[service_name] }}"
+  file:
+    path: "{{ node_config_directory }}/{{ service_name }}"
+    state: "directory"
+    owner: "{{ config_owner_user }}"
+    group: "{{ config_owner_group }}"
+    mode: "0770"
+  when: service | service_enabled_and_mapped_to_host
+
 - name: Copying over eswitchd.conf
   become: true
   vars:


### PR DESCRIPTION
## Summary
- skip eswitchd configuration unless service is enabled and host is targeted
- align eswitchd config directory handling with other Neutron agents

## Testing
- `tox -e linters` *(fails: bandit detected issues)*

------
https://chatgpt.com/codex/tasks/task_e_68879778aea083279fec1e0e976d5589