### PR TITLE
Fix conditional creation of Neutron agent configs

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -227,8 +227,9 @@
     mode: "0770"
   loop: "{{ neutron_services | dict2items }}"
   when:
+    - enable_neutron | bool
     - item.key == 'neutron-linuxbridge-agent'
-    - not (item.value.enabled | bool)
+    - item.value.enabled | bool
     - item.value.host_in_groups | default(false) | bool
 
 - name: Ensuring neutron-linuxbridge-agent config directory exists
@@ -282,8 +283,9 @@
     mode: "0770"
   loop: "{{ neutron_services | dict2items }}"
   when:
+    - enable_neutron | bool
     - item.key == 'neutron-sriov-agent'
-    - not (item.value.enabled | bool)
+    - item.value.enabled | bool
     - item.value.host_in_groups | default(false) | bool
 
 - name: Ensuring neutron-sriov-agent config directory exists
@@ -322,8 +324,9 @@
     mode: "0770"
   loop: "{{ neutron_services | dict2items }}"
   when:
+    - enable_neutron | bool
     - item.key == 'neutron-mlnx-agent'
-    - not (item.value.enabled | bool)
+    - item.value.enabled | bool
     - item.value.host_in_groups | default(false) | bool
 
 - name: Ensuring neutron-mlnx-agent config directory exists
@@ -362,8 +365,9 @@
     mode: "0770"
   loop: "{{ neutron_services | dict2items }}"
   when:
+    - enable_neutron | bool
     - item.key == 'neutron-eswitchd'
-    - not (item.value.enabled | bool)
+    - item.value.enabled | bool
     - item.value.host_in_groups | default(false) | bool
 
 - name: Ensuring neutron-eswitchd config directory exists


### PR DESCRIPTION
## Summary
- ensure agent specific config directories are only created when the service is enabled and mapped to the host
- update tasks for linuxbridge, sriov, mlnx and eswitchd agents

## Testing
- `ansible-playbook -i ansible/inventory/all-in-one ansible/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_68879bd9a98083278a3140a6704638d3