### PR TITLE
Guard per-agent config tasks in neutron

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -21,7 +21,9 @@
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
     mode: "0770"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-openvswitch-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-openvswitch-agent']
 
 
 - name: Check if extra ml2 plugins exists
@@ -42,7 +44,9 @@
   stat:
     path: "{{ node_config_directory }}/neutron-tls-proxy/"
   register: neutron_tls_proxy_dir
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-tls-proxy']['enabled'] | bool
+    - inventory_hostname in groups['neutron-tls-proxy']
 
 - name: Check neutron TLS cert file
   vars:
@@ -51,7 +55,8 @@
     path: "{{ node_config_directory }}/neutron-tls-proxy/neutron-cert.pem"
   register: neutron_tls_cert
   when:
-    - service | service_enabled_and_mapped_to_host
+    - neutron_services['neutron-tls-proxy']['enabled'] | bool
+    - inventory_hostname in groups['neutron-tls-proxy']
     - neutron_tls_proxy_dir.stat.exists
 
 - name: Check neutron TLS key file
@@ -61,7 +66,8 @@
     path: "{{ node_config_directory }}/neutron-tls-proxy/neutron-key.pem"
   register: neutron_tls_key
   when:
-    - service | service_enabled_and_mapped_to_host
+    - neutron_services['neutron-tls-proxy']['enabled'] | bool
+    - inventory_hostname in groups['neutron-tls-proxy']
     - neutron_tls_proxy_dir.stat.exists
 
 - name: Creating TLS backend PEM File
@@ -75,7 +81,8 @@
     remote_src: true
   become: true
   when:
-    - service | service_enabled_and_mapped_to_host
+    - neutron_services['neutron-tls-proxy']['enabled'] | bool
+    - inventory_hostname in groups['neutron-tls-proxy']
     - neutron_tls_proxy_dir.stat.exists
     - neutron_tls_cert.stat.exists
     - neutron_tls_key.stat.exists
@@ -198,7 +205,9 @@
     src: "id_rsa"
     dest: "{{ node_config_directory }}/neutron-server/id_rsa"
     mode: 0600
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-ovn-metadata-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-ovn-metadata-agent']
 
 - name: Copying over ml2_conf.ini
   become: true
@@ -227,10 +236,9 @@
     mode: "0770"
   loop: "{{ neutron_services | dict2items }}"
   when:
-    - enable_neutron | bool
     - item.key == 'neutron-linuxbridge-agent'
-    - item.value.enabled | bool
-    - item.value.host_in_groups | default(false) | bool
+    - neutron_services['neutron-linuxbridge-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-linuxbridge-agent']
 
 - name: Ensuring neutron-linuxbridge-agent config directory exists
   become: true
@@ -243,7 +251,9 @@
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
     mode: "0770"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-linuxbridge-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-linuxbridge-agent']
 
 - name: Copying over linuxbridge_agent.ini
   become: true
@@ -257,7 +267,9 @@
       - "{{ node_custom_config }}/neutron/{{ inventory_hostname }}/linuxbridge_agent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/linuxbridge_agent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-linuxbridge-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-linuxbridge-agent']
 
 - name: Copying over openvswitch_agent.ini
   become: true
@@ -271,7 +283,9 @@
       - "{{ node_custom_config }}/neutron/{{ inventory_hostname }}/openvswitch_agent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/openvswitch_agent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-metadata-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-metadata-agent']
 
 
 - name: Ensure sriov agent config dir exists
@@ -283,10 +297,9 @@
     mode: "0770"
   loop: "{{ neutron_services | dict2items }}"
   when:
-    - enable_neutron | bool
     - item.key == 'neutron-sriov-agent'
-    - item.value.enabled | bool
-    - item.value.host_in_groups | default(false) | bool
+    - neutron_services['neutron-sriov-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-sriov-agent']
 
 - name: Ensuring neutron-sriov-agent config directory exists
   become: true
@@ -299,7 +312,9 @@
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
     mode: "0770"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-sriov-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-sriov-agent']
 
 - name: Copying over sriov_agent.ini
   become: true
@@ -313,7 +328,9 @@
       - "{{ node_custom_config }}/neutron/{{ inventory_hostname }}/sriov_agent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/sriov_agent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-sriov-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-sriov-agent']
 
 - name: Ensure mlnx agent config dir exists
   file:
@@ -324,10 +341,9 @@
     mode: "0770"
   loop: "{{ neutron_services | dict2items }}"
   when:
-    - enable_neutron | bool
     - item.key == 'neutron-mlnx-agent'
-    - item.value.enabled | bool
-    - item.value.host_in_groups | default(false) | bool
+    - neutron_services['neutron-mlnx-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-mlnx-agent']
 
 - name: Ensuring neutron-mlnx-agent config directory exists
   become: true
@@ -369,10 +385,9 @@
     mode: "0770"
   loop: "{{ neutron_services | dict2items }}"
   when:
-    - enable_neutron | bool
     - item.key == 'neutron-eswitchd'
-    - item.value.enabled | bool
-    - item.value.host_in_groups | default(false) | bool
+    - neutron_services['neutron-eswitchd']['enabled'] | bool
+    - inventory_hostname in groups['neutron-eswitchd']
 
 - name: Ensuring neutron-eswitchd config directory exists
   become: true
@@ -434,7 +449,9 @@
     - "{{ node_custom_config }}/neutron/{{ inventory_hostname }}/dnsmasq.conf"
     - "{{ node_custom_config }}/neutron/dnsmasq.conf"
     - "dnsmasq.conf.j2"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-dhcp-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-dhcp-agent']
 
 - name: Copying over l3_agent.ini
   become: true
@@ -451,6 +468,8 @@
     mode: "0660"
   when:
     - item.key in services_need_l3_agent_ini
+    - neutron_services[item.key]['enabled'] | bool
+    - inventory_hostname in groups[item.key]
   with_dict: "{{ neutron_services | select_services_enabled_and_mapped_to_host }}"
 
 - name: Copying over fwaas_driver.ini
@@ -482,7 +501,9 @@
       - "{{ node_custom_config }}/neutron/metadata_agent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/metadata_agent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-metadata-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-metadata-agent']
 
 - name: Copying over neutron_ovn_metadata_agent.ini
   become: true
@@ -495,7 +516,9 @@
       - "{{ node_custom_config }}/neutron/neutron_ovn_metadata_agent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/neutron_ovn_metadata_agent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-ovn-metadata-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-ovn-metadata-agent']
 
 - name: Copying over metering_agent.ini
   become: true
@@ -508,7 +531,9 @@
       - "{{ node_custom_config }}/neutron/metering_agent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/metering_agent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-metering-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-metering-agent']
 
 - name: Copying over ironic_neutron_agent.ini
   become: true
@@ -521,7 +546,9 @@
       - "{{ node_custom_config }}/neutron/ironic_neutron_agent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/ironic_neutron_agent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['ironic-neutron-agent']['enabled'] | bool
+    - inventory_hostname in groups['ironic-neutron-agent']
 
 - name: Copying over bgp_dragent.ini
   become: true
@@ -534,7 +561,9 @@
       - "{{ node_custom_config }}/neutron/bgp_dragent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/bgp_dragent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-bgp-dragent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-bgp-dragent']
 
 - name: Copying over ovn_agent.ini
   become: true
@@ -547,7 +576,9 @@
       - "{{ node_custom_config }}/neutron/ovn_agent.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/ovn_agent.ini"
     mode: "0660"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-ovn-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-ovn-agent']
 
 - name: Copying over nsx.ini
   become: true
@@ -562,7 +593,8 @@
     dest: "{{ node_config_directory }}/{{ service_name }}/nsx.ini"
     mode: "0660"
   when:
-    - service | service_enabled_and_mapped_to_host
+    - neutron_services['neutron-server']['enabled'] | bool
+    - inventory_hostname in groups['neutron-server']
     - neutron_plugin_agent in ['vmware_nsxv', 'vmware_nsxv3', 'vmware_nsxp', 'vmware_dvs']
 
 - name: Copy neutron-l3-agent-wrapper script
@@ -574,7 +606,9 @@
     src: neutron-l3-agent-wrapper.sh.j2
     dest: "{{ node_config_directory }}/{{ service_name }}/neutron-l3-agent-wrapper.sh"
     mode: "0770"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-l3-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-l3-agent']
 
 - name: Copying over extra ml2 plugins
   become: true
@@ -610,7 +644,8 @@
     - "{{ node_custom_config }}/neutron/neutron-tls-proxy.cfg"
     - "neutron-tls-proxy.cfg.j2"
   when:
-    - service | service_enabled_and_mapped_to_host
+    - neutron_services['neutron-tls-proxy']['enabled'] | bool
+    - inventory_hostname in groups['neutron-tls-proxy']
     - neutron_tls_proxy_dir.stat.exists
 
 - name: Copying over neutron_taas.conf
@@ -648,7 +683,9 @@
     - "{{ ovs_agent_dir }}/config.json"
     - "{{ ovs_agent_dir }}/neutron.conf"
     - "{{ ovs_agent_dir }}/openvswitch_agent.ini"
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - neutron_services['neutron-openvswitch-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-openvswitch-agent']
 
 - name: Copy neutron-ovs-cleanup ML2 plugin configs
   become: true
@@ -663,7 +700,8 @@
     dest: "{{ cleanup_dir }}/{{ item.path | basename }}"
     mode: "0660"
   when:
-    - service | service_enabled_and_mapped_to_host
+    - neutron_services['neutron-openvswitch-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-openvswitch-agent']
     - check_extra_ml2_plugins is defined
     - check_extra_ml2_plugins.matched > 0
   loop: "{{ check_extra_ml2_plugins.files }}"
@@ -681,5 +719,6 @@
     dest: "{{ cleanup_dir }}/{{ neutron_policy_file }}"
     mode: "0660"
   when:
-    - service | service_enabled_and_mapped_to_host
+    - neutron_services['neutron-openvswitch-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-openvswitch-agent']
     - neutron_policy_file is defined


### PR DESCRIPTION
## Summary
- ensure every agent-specific config task has the standard guard
- prevent failures on stand-alone compute hosts

## Testing
- `ansible-playbook --syntax-check ansible/site.yml`


------
https://chatgpt.com/codex/tasks/task_e_6887a27a92a88327a01dbddcd5fc523b