### PR TITLE
Fix neutron_ovs_cleanup image

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -41,7 +41,7 @@
     common_options: "{{ docker_common_options }}"
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
-    image: "{{ service.image }}"
+    image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""
@@ -64,7 +64,7 @@
     common_options: "{{ docker_common_options }}"
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
-    image: "{{ service.image }}"
+    image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""
@@ -89,7 +89,7 @@
     detach: False
     command: >-
       bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
-    image: "{{ service.image }}"
+    image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""


### PR DESCRIPTION
## Summary
- ensure neutron_ovs_cleanup runs with the neutron-openvswitch-agent image

## Testing
- `tox -e linters` *(fails: bandit reports issues)*

------
https://chatgpt.com/codex/tasks/task_e_6887a86f787483278e0a2c4bb2a321f6