### PR TITLE
Fix pid_mode kw for podman client

### DIFF
--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -133,7 +133,7 @@ class PodmanWorker(ContainerWorker):
         convert_keys = dict(
             graceful_timeout="stop_timeout",
             cgroupns_mode="cgroupns",
-            pid_mode="pid",
+            pid_mode="pid_mode",
         )
 
         # remap differing args
@@ -321,8 +321,8 @@ class PodmanWorker(ContainerWorker):
     def compare_pid_mode(self, container_info):
         new_pid_mode = self.params.get("pid_mode") or self.params.get("pid")
         current_pid_mode = (
-            container_info["HostConfig"].get("PidMode")
-            or container_info["HostConfig"].get("PidNS")
+            container_info["HostConfig"].get("PidMode") or
+            container_info["HostConfig"].get("PidNS")
         )
 
         if not current_pid_mode:

--- a/tests/kolla_container_tests/test_podman_worker.py
+++ b/tests/kolla_container_tests/test_podman_worker.py
@@ -218,7 +218,7 @@ class TestContainer(base.BaseTestCase):
         params.update({'pid_mode': 'host', 'cgroupns_mode': 'host'})
         self.pw = get_PodmanWorker(params)
         args = self.pw.prepare_container_args()
-        self.assertEqual('host', args.get('pid'))
+        self.assertEqual('host', args.get('pid_mode'))
         self.assertEqual('host', args.get('cgroupns'))
 
     def test_create_container_with_dimensions(self):


### PR DESCRIPTION
## Summary
- ensure Podman uses `pid_mode` argument
- update unit tests for the new kw

## Testing
- `flake8 ansible/module_utils/kolla_podman_worker.py tests/kolla_container_tests/test_podman_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_6887b6fabeb483278616ab39c0374cc9