### PR TITLE
Implement compute service start ordering

### DIFF
--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Default start priority for compute node services
+kolla_service_start_priority: []

--- a/ansible/roles/service-start-order/handlers/main.yml
+++ b/ansible/roles/service-start-order/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  become: true
+  command: systemctl daemon-reload

--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -1,0 +1,47 @@
+---
+- name: Build start order pairs
+  set_fact:
+    start_order_pairs: "{{ kolla_service_start_priority[:-1] | zip(kolla_service_start_priority[1:]) | list }}"
+  run_once: true
+
+- name: Ensure override directories exist
+  become: true
+  file:
+    path: "/etc/systemd/system/kolla-{{ item.1 }}-container.service.d"
+    state: directory
+  loop: "{{ start_order_pairs }}"
+  notify: Reload systemd
+
+- name: Configure start order overrides
+  become: true
+  copy:
+    dest: "/etc/systemd/system/kolla-{{ item.1 }}-container.service.d/start-order.conf"
+    content: |
+      [Unit]
+      After=kolla-{{ item.0 }}-container.service
+      Requires=kolla-{{ item.0 }}-container.service
+    mode: "0644"
+  loop: "{{ start_order_pairs }}"
+  notify: Reload systemd
+
+- name: Start compute services in order
+  become: true
+  block:
+    - name: Start {{ item }} service
+      systemd:
+        name: "kolla-{{ item }}-container.service"
+        state: started
+        enabled: true
+    - name: Wait for neutron_ovs_cleanup to finish
+      kolla_container_facts:
+        action: get_containers_state
+        container_engine: "{{ kolla_container_engine }}"
+        name: neutron_ovs_cleanup
+      register: cleanup_state
+      retries: 12
+      delay: 5
+      until: cleanup_state.states.neutron_ovs_cleanup != 'running'
+      when: item == 'neutron_ovs_cleanup'
+  loop: "{{ kolla_service_start_priority }}"
+  loop_control:
+    label: "{{ item }}"

--- a/ansible/roles/service-start-order/tasks/main.yml
+++ b/ansible/roles/service-start-order/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include_tasks: deploy.yml
+  when: kolla_action in ['deploy', 'reconfigure']

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1052,3 +1052,11 @@
   roles:
     - { role: collectd,
         tags: collectd }
+
+- name: Configure compute service start order
+  gather_facts: false
+  hosts:
+    - compute
+  roles:
+    - { role: service-start-order,
+        tags: service-start-order }

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -315,6 +315,32 @@ To specify additional volumes for a single container, set
   nova_libvirt_extra_volumes:
     - "/etc/foo:/etc/foo"
 
+Service start order
+~~~~~~~~~~~~~~~~~~~
+
+Compute node services are started in the order defined by the variable
+``kolla_service_start_priority``.  The list may be overridden in
+``/etc/kolla/globals.yml`` to adjust the startup sequence.
+
+.. code-block:: yaml
+
+   kolla_service_start_priority:
+     - kolla_toolbox
+     - openvswitch_db
+     - openvswitch_vswitchd
+     - neutron_ovs_cleanup
+     - neutron_openvswitch_agent
+     - nova_libvirt
+     - nova_ssh
+     - nova_compute
+     - ceilometer_compute
+     - collectd
+
+Services start sequentially when a compute host boots or during
+``kolla-ansible deploy`` and ``reconfigure`` runs.  The
+``neutron_openvswitch_agent`` service waits for
+``neutron_ovs_cleanup`` to complete before starting.
+
 Migrate container engine
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary
- ensure compute container services start in priority order
- generate systemd overrides to encode ordering
- document `kolla_service_start_priority`

## Testing
- `tox -e linters` *(fails: bandit reported issues)*

------
https://chatgpt.com/codex/tasks/task_e_688b4da3b6fc832781acd60d05c899e9