### PR TITLE
Fix become issue in service-start-order role

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -25,7 +25,6 @@
   notify: Reload systemd
 
 - name: Start compute services in order
-  become: true
   include_tasks: start_service.yml
   loop: "{{ kolla_service_start_priority }}"
   loop_control:

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -1,10 +1,12 @@
 - name: Start {{ item }} service
+  become: true
   systemd:
     name: "kolla-{{ item }}-container.service"
     state: started
     enabled: true
 
 - name: Wait for neutron_ovs_cleanup to finish
+  become: true
   kolla_container_facts:
     action: get_containers_state
     container_engine: "{{ kolla_container_engine }}"


### PR DESCRIPTION
## Summary
- avoid using `become` on `include_tasks` which older Ansible doesn't support
- apply privilege escalation to start_service.yml tasks

## Testing
- `tox -e pep8`
- `tox -e ansible-lint` *(fails: AttributeError in validate-all-file.py)*

------
https://chatgpt.com/codex/tasks/task_e_688b6c65d3d88327920e212efd0d26c1