### PR TITLE
Fix kolla-toolbox podman run volume

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -100,7 +100,8 @@ kolla_toolbox_default_volumes:
   - "/etc/localtime:/etc/localtime:ro"
   - "{{ '/etc/timezone:/etc/timezone:ro' if ansible_facts.os_family == 'Debian' else '' }}"
   - "/dev/:/dev/"
-  - "/run/:/run/{{ ':shared' if kolla_container_engine == 'docker' else '' }}"   # see: https://github.com/containers/podman/issues/16305
+  - "{{ '/run/:/run/:shared' if kolla_container_engine == 'docker' else '' }}"   # see: https://github.com/containers/podman/issues/16305
+  # Podman cannot safely mount the whole /run directory
   - "kolla_logs:/var/log/kolla/"
 cron_default_volumes:
   - "{{ node_config_directory }}/cron/:{{ container_config_directory }}/:ro"


### PR DESCRIPTION
## Summary
- adjust kolla-toolbox default volumes
  - do not mount /run on podman
  - document the podman limitation

## Testing
- `tox -e py3 --skip-pkg-install` *(fails: TestResult has no addDuration method)*

------
https://chatgpt.com/codex/tasks/task_e_688b766c9494832783cba5f58da27a14