### PR TITLE
Fix repeated neutron_ovs_cleanup execution

### DIFF
--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -1,9 +1,18 @@
+- name: Check neutron_ovs_cleanup marker
+  become: true
+  stat:
+    path: "{{ neutron_ovs_cleanup_marker_file }}"
+  register: ovs_cleanup_marker
+  when: item == 'neutron_ovs_cleanup'
+
 - name: Start {{ item }} service
   become: true
   systemd:
     name: "kolla-{{ item }}-container.service"
     state: started
     enabled: true
+  when:
+    - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
 
 - name: Wait for neutron_ovs_cleanup to finish
   become: true
@@ -15,4 +24,6 @@
   retries: 12
   delay: 5
   until: cleanup_state.states.neutron_ovs_cleanup != 'running'
-  when: item == 'neutron_ovs_cleanup'
+  when:
+    - item == 'neutron_ovs_cleanup'
+    - not ovs_cleanup_marker.stat.exists | default(false)

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -341,6 +341,9 @@ Services start sequentially when a compute host boots or during
 ``kolla-ansible deploy`` and ``reconfigure`` runs.  The
 ``neutron_openvswitch_agent`` service waits for
 ``neutron_ovs_cleanup`` to complete before starting.
+The cleanup container executes only once per host boot; when the marker
+file ``/tmp/kolla/neutron_ovs_cleanup/done`` is present, the
+``service-start-order`` role skips starting the container.
 
 Migrate container engine
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
- service-start-order: skip neutron_ovs_cleanup if marker file exists
- document how the marker file interacts with service-start-order

## Testing
- `tox -e linters` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688b7bd275bc83279e7e7c7d959b9180