### PR TITLE
Fix neutron_ovs_cleanup marker handling

### DIFF
--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -11,3 +11,9 @@ kolla_service_start_priority:
   - nova_compute
   - ceilometer_compute
   - collectd
+
+#####################
+# OVS cleanup
+#####################
+# Marker file used to ensure neutron_ovs_cleanup runs only once per boot
+neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup/done"

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -344,6 +344,8 @@ Services start sequentially when a compute host boots or during
 The cleanup container executes only once per host boot; when the marker
 file ``/tmp/kolla/neutron_ovs_cleanup/done`` is present, the
 ``service-start-order`` role skips starting the container.
+The marker path may be customised via the variable
+``neutron_ovs_cleanup_marker_file``.
 
 Migrate container engine
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -18,6 +18,8 @@ further automatic executions until the host is rebooted. If the container
 configuration changes, the playbook recreates the container so the updated
 settings will be applied on the next run, but the container does not execute
 again while the marker file exists.
+The marker path can be changed by overriding the variable
+``neutron_ovs_cleanup_marker_file``.
 
 Manual execution
 ----------------


### PR DESCRIPTION
## Summary
- define `neutron_ovs_cleanup_marker_file` in service-start-order defaults
- document how to override the marker file path

## Testing
- `tox -e linters` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688b807f81308327b3c1588e9260b9b9