### PR TITLE
Ensure extra volume bind paths exist

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -24,7 +24,7 @@ COMPARE_CONFIG_CMD = ["/usr/local/bin/kolla_set_configs", "--check"]
 LOG = logging.getLogger(__name__)
 
 # functions exported for use by other module_utils
-__all__ = ["_as_iter", "_as_dict"]
+__all__ = ["_as_iter", "_as_dict", "ensure_host_path"]
 
 
 def _normalise_caps(value):
@@ -272,6 +272,20 @@ def _compare_volumes(spec, running) -> bool:
         return True
 
     return False
+
+
+def ensure_host_path(path: str) -> None:
+    """Ensure that a host directory used for a bind mount exists.
+
+    Creates *path* with ``0755`` permissions if it does not already exist.
+    The call is idempotent and will not raise an error if the directory
+    exists.
+    """
+
+    if not path or not str(path).startswith("/"):
+        return
+    if not os.path.exists(path):
+        os.makedirs(path, mode=0o755, exist_ok=True)
 
 
 def _compare_ulimits(spec, running) -> bool:

--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -21,6 +21,7 @@ from ansible.module_utils.kolla_container_worker import (
     _as_dict,
     _compare_volumes,
     _compare_ulimits,
+    ensure_host_path,
 )
 
 
@@ -639,11 +640,21 @@ class PodmanWorker(ContainerWorker):
         volumes = self.params.get("volumes", []) or []
 
         for volume in volumes:
-            volume_name = volume.split(":")[0]
-            if "/" in volume_name:
+            if isinstance(volume, dict):
+                src = volume.get("Source") or ""
+                if volume.get("Type") == "volume" and volume.get("Name"):
+                    self.create_volume(name=volume["Name"])
+                elif src and src.startswith("/"):
+                    ensure_host_path(src)
+                elif src and "/" not in src:
+                    self.create_volume(name=src)
                 continue
 
-            self.create_volume(name=volume_name)
+            volume_name = str(volume).split(":", 1)[0]
+            if volume_name.startswith("/"):
+                ensure_host_path(volume_name)
+            elif volume_name:
+                self.create_volume(name=volume_name)
 
     def remove_volume(self):
         if self.check_volume():

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -315,6 +315,11 @@ To specify additional volumes for a single container, set
   nova_libvirt_extra_volumes:
     - "/etc/foo:/etc/foo"
 
+Kolla Ansible automatically creates any missing host directories
+referenced in ``*_extra_volumes`` with ownership ``root:root`` and
+permissions ``0755``. This removes the need to pre-create such
+directories before running the deployment.
+
 Service start order
 ~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -7,3 +7,7 @@ some fields returned by ``podman inspect``.  ``PidMode`` became
 accepts either name when comparing containers and passes the correct
 ``--pid`` and ``--cgroupns`` options to ``podman`` when creating
 containers.
+
+When using ``*_extra_volumes`` options, Kolla Ansible will automatically
+create any missing host directories referenced by bind mounts with
+permissions ``0755`` before starting containers.

--- a/releasenotes/notes/auto-create-extra-volume-dirs.yaml
+++ b/releasenotes/notes/auto-create-extra-volume-dirs.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Kolla-Ansible now automatically creates host directories referenced in any
+    ``*_extra_volumes`` option, removing the need for manual directory preparation.

--- a/tests/unit/common/test_volume_paths.py
+++ b/tests/unit/common/test_volume_paths.py
@@ -1,0 +1,17 @@
+from unittest import TestCase, mock
+
+from ansible.module_utils.kolla_container_worker import ensure_host_path
+
+
+class TestEnsureHostPath(TestCase):
+    def test_creates_missing_dir(self):
+        with mock.patch('os.path.exists', return_value=False), \
+             mock.patch('os.makedirs') as makedirs:
+            ensure_host_path('/var/lib/custom')
+            makedirs.assert_called_once_with('/var/lib/custom', mode=0o755, exist_ok=True)
+
+    def test_skips_existing_dir(self):
+        with mock.patch('os.path.exists', return_value=True), \
+             mock.patch('os.makedirs') as makedirs:
+            ensure_host_path('/var/lib/custom')
+            makedirs.assert_not_called()


### PR DESCRIPTION
## Summary
- pre-create host directories referenced by bind mounts
- document automatic creation of `*_extra_volumes` paths
- add unit tests for volume path creation

## Testing
- `tox -e py3 -- tests.unit.common.test_volume_paths.TestEnsureHostPath.test_creates_missing_dir` *(fails: The specified regex doesn't match with anything)*
- `tox -e docs` *(fails: missing pcre.h for python-pcre)*

------
https://chatgpt.com/codex/tasks/task_e_6891ee0fd8388327938ec3aa79008be8