### PR TITLE
Handle containers lacking systemd units in service-check-containers

### DIFF
--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -42,16 +42,25 @@
     container_inspect: >-
       {{ (inspect_result.containers | default({})).get(container_name, {}) }}
 
+- name: Check unit file exists
+  become: true
+  stat:
+    path: "/etc/systemd/system/{{ unit_name }}"
+  register: unit_file
+  changed_when: false
+  failed_when: false
+
 - name: Check unit enabled
   become: true
   command: systemctl is-enabled --quiet {{ unit_name }}
   register: unit_enabled_res
   changed_when: false
   failed_when: false
+  when: unit_file.stat.exists
 
 - name: Set unit enabled fact
   set_fact:
-    unit_enabled: "{{ unit_enabled_res.rc == 0 }}"
+    unit_enabled: "{{ unit_file.stat.exists and (unit_enabled_res.rc | default(1)) == 0 }}"
 
 - name: Check unit active
   become: true
@@ -59,13 +68,14 @@
   register: unit_active
   changed_when: false
   failed_when: false
+  when: unit_file.stat.exists
 
 - name: Record container and unit status
   set_fact:
     container_missing: "{{ container_result.rc != 0 }}"
     unit_missing_or_disabled: "{{ not unit_enabled }}"
     needs_start: >-
-      {{ container_result.rc != 0 or not unit_enabled or unit_active.rc != 0 }}
+      {{ container_result.rc != 0 or (unit_file.stat.exists and (not unit_enabled or unit_active.rc | default(3) != 0)) }}
 
 - name: Detect health-check drift
   set_fact:
@@ -107,4 +117,5 @@
     enabled: true
   when:
     - not container_missing
-    - unit_active.rc != 0
+    - unit_file.stat.exists
+    - (unit_active.rc | default(0)) != 0

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -19,3 +19,4 @@ Projects Deployment Configuration Reference
    deployment-and-bootstrapping/index
    high-availability/index
    rating/index
+   podman

--- a/doc/source/reference/podman.rst
+++ b/doc/source/reference/podman.rst
@@ -1,0 +1,18 @@
+============================
+Podman Container Management
+============================
+
+Some Kolla Ansible containers may be started outside of systemd and therefore
+lack a corresponding ``container-<name>.service`` unit. A common example is
+``kolla_toolbox``, which is launched during bootstrap and left running.
+
+The ``service-check-containers`` role verifies that containers and their
+systemd units are active. When using Podman, the role now checks for the
+presence of a unit file before attempting to manage it. If no unit file is
+found, systemd operations are skipped and the container is assumed to be
+running as-is.
+
+.. note::
+
+   This behaviour ensures deployments succeed even when containers such as
+   ``kolla_toolbox`` are running without a systemd unit.

--- a/molecule/service_check_no_unit/molecule.yml
+++ b/molecule/service_check_no_unit/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/service_check_no_unit/playbook.yml
+++ b/molecule/service_check_no_unit/playbook.yml
@@ -1,0 +1,29 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:  # noqa var-naming[read-only]
+      control:
+        - localhost
+    project_name: testnu
+    testnu_services:
+      toolbox:
+        container_name: kolla_toolbox
+        group: control
+        enabled: true
+        image: docker.io/library/busybox:latest
+    kolla_container_engine: podman
+    docker_common_options: {}
+  tasks:
+    - name: Ensure kolla_toolbox container is running without unit
+      become: true
+      command: >-
+        podman run -d --name kolla_toolbox docker.io/library/busybox:latest tail -f /dev/null
+      register: toolbox_run
+      changed_when: toolbox_run.rc == 0
+      failed_when: toolbox_run.rc not in [0,125]
+
+    - name: Run service-check-containers role
+      include_role:
+        name: service-check-containers

--- a/molecule/service_check_no_unit/verify.yml
+++ b/molecule/service_check_no_unit/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check container exists
+      become: true
+      command: podman container exists kolla_toolbox
+
+    - name: Check no systemd unit exists
+      become: true
+      stat:
+        path: /etc/systemd/system/container-kolla_toolbox.service
+      register: toolbox_unit
+
+    - name: Fail if unit exists
+      fail:
+        msg: "Unit should not exist"
+      when: toolbox_unit.stat.exists


### PR DESCRIPTION
## Summary
- skip systemd check when container unit file is absent
- document Podman behaviour for containers without units
- add molecule scenario covering kolla_toolbox without a unit

## Testing
- `tox -e linters` *(fails: ansible-lint reports duplicate keys and other issues in unrelated files)*
- `tox -e docs`
- `ansible-lint ansible/roles/service-check-containers/tasks/verify.yml molecule/service_check_no_unit/playbook.yml molecule/service_check_no_unit/verify.yml`
- `ansible-playbook molecule/service_check_no_unit/playbook.yml` *(fails: netavark setns: Operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_689376a8adbc832788e8d865a48458a4