### PR TITLE
skip unitless services in start order

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -1,8 +1,15 @@
 ---
+- name: Detect services with systemd units
+  become: true
+  stat:
+    path: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+  loop: "{{ kolla_service_start_priority }}"
+  register: service_units
+
 - name: Build start order pairs
   set_fact:
-    start_order_pairs: "{{ kolla_service_start_priority[:-1] | zip(kolla_service_start_priority[1:]) | list }}"
-  run_once: true
+    start_order_services: "{{ service_units.results | json_query('[?stat.exists].item') }}"
+    start_order_pairs: "{{ start_order_services[:-1] | zip(start_order_services[1:]) | list }}"
 
 - name: Ensure override directories exist
   become: true

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -5,6 +5,12 @@
   register: ovs_cleanup_marker
   when: item == 'neutron_ovs_cleanup'
 
+- name: Check if {{ item }} unit file exists
+  become: true
+  stat:
+    path: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+  register: service_unit
+
 - name: Start {{ item }} service
   become: true
   systemd:
@@ -13,6 +19,7 @@
     enabled: true
   when:
     - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
+    - service_unit.stat.exists
 
 - name: Wait for neutron_ovs_cleanup to finish
   become: true
@@ -26,4 +33,5 @@
   until: cleanup_state.states.neutron_ovs_cleanup != 'running'
   when:
     - item == 'neutron_ovs_cleanup'
+    - service_unit.stat.exists
     - not ovs_cleanup_marker.stat.exists | default(false)

--- a/doc/source/reference/podman.rst
+++ b/doc/source/reference/podman.rst
@@ -6,13 +6,14 @@ Some Kolla Ansible containers may be started outside of systemd and therefore
 lack a corresponding ``container-<name>.service`` unit. A common example is
 ``kolla_toolbox``, which is launched during bootstrap and left running.
 
-The ``service-check-containers`` role verifies that containers and their
-systemd units are active. When using Podman, the role now checks for the
-presence of a unit file before attempting to manage it. If no unit file is
-found, systemd operations are skipped and the container is assumed to be
-running as-is.
+The ``service-check-containers`` and ``service-start-order`` roles verify and
+start containers via their systemd units. When using Podman, these roles check
+for the presence of a unit file before attempting any systemd operation. If no
+unit file is found, systemd actions are skipped and the container is assumed to
+be running as-is.
 
 .. note::
 
    This behaviour ensures deployments succeed even when containers such as
-   ``kolla_toolbox`` are running without a systemd unit.
+   ``kolla_toolbox`` are running without a systemd unit, both during service
+   checks and while applying start-order sequencing.

--- a/molecule/service_start_order_no_unit/molecule.yml
+++ b/molecule/service_start_order_no_unit/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/service_start_order_no_unit/playbook.yml
+++ b/molecule/service_start_order_no_unit/playbook.yml
@@ -1,0 +1,31 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:  # noqa var-naming[read-only]
+      control:
+        - localhost
+    project_name: testnu
+    testnu_services:
+      toolbox:
+        container_name: kolla_toolbox
+        group: control
+        enabled: true
+        image: docker.io/library/busybox:latest
+    kolla_container_engine: podman
+    docker_common_options: {}
+    kolla_service_start_priority:
+      - kolla_toolbox
+  tasks:
+    - name: Ensure kolla_toolbox container is running without unit
+      become: true
+      command: >-
+        podman run -d --name kolla_toolbox docker.io/library/busybox:latest tail -f /dev/null
+      register: toolbox_run
+      changed_when: toolbox_run.rc == 0
+      failed_when: toolbox_run.rc not in [0,125]
+
+    - name: Run service-start-order role
+      include_role:
+        name: service-start-order

--- a/molecule/service_start_order_no_unit/verify.yml
+++ b/molecule/service_start_order_no_unit/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check container exists
+      become: true
+      command: podman container exists kolla_toolbox
+
+    - name: Check no systemd unit exists
+      become: true
+      stat:
+        path: /etc/systemd/system/container-kolla_toolbox.service
+      register: toolbox_unit
+
+    - name: Fail if unit exists
+      fail:
+        msg: "Unit should not exist"
+      when: toolbox_unit.stat.exists

--- a/releasenotes/notes/service-start-order-skip-unitless-2e3b6f23e3d7aee7.yaml
+++ b/releasenotes/notes/service-start-order-skip-unitless-2e3b6f23e3d7aee7.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The ``service-start-order`` role no longer fails when containers listed in
+    ``kolla_service_start_priority`` do not have corresponding systemd unit
+    files. Containers such as ``kolla_toolbox`` are now skipped, allowing the
+    playbook to complete successfully when running under Podman.


### PR DESCRIPTION
## Summary
- skip containers without systemd unit when building start order
- avoid starting services without unit files
- document Podman behaviour and add test scenario

## Testing
- `python3 -m tox -e linters`
- `python3 -m tox -e docs`
- `python3 -m molecule test -s service_start_order_no_unit --driver-name default` *(fails: `Error: netavark: setns: IO error: Operation not permitted`)*


------
https://chatgpt.com/codex/tasks/task_e_68948a049ea483279df458e00dfd8840