### PR TITLE
service-start-order: fix uninitialized start_order_services

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -6,9 +6,12 @@
   loop: "{{ kolla_service_start_priority }}"
   register: service_units
 
-- name: Build start order pairs
+- name: Build list of services with systemd units
   set_fact:
     start_order_services: "{{ service_units.results | json_query('[?stat.exists].item') }}"
+
+- name: Build start order pairs
+  set_fact:
     start_order_pairs: "{{ start_order_services[:-1] | zip(start_order_services[1:]) | list }}"
 
 - name: Ensure override directories exist

--- a/molecule/service_start_order_no_unit/playbook.yml
+++ b/molecule/service_start_order_no_unit/playbook.yml
@@ -29,3 +29,8 @@
     - name: Run service-start-order role
       include_role:
         name: service-start-order
+
+    - name: Assert start_order_services is defined and empty
+      assert:
+        that:
+          - start_order_services == []

--- a/releasenotes/notes/fix-start-order-services-ec1375f4c3470e1a.yaml
+++ b/releasenotes/notes/fix-start-order-services-ec1375f4c3470e1a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Ensure the ``service-start-order`` role defines the
+    ``start_order_services`` variable before building dependency
+    pairs. This prevents undefined variable errors when ordering
+    compute services.


### PR DESCRIPTION
## Summary
- ensure the service-start-order role defines `start_order_services` before computing pairs
- assert variable initialization in service_start_order_no_unit scenario
- document the fix

## Testing
- `python3 -m ansiblelint ansible/roles/service-start-order/tasks/deploy.yml molecule/service_start_order_no_unit/playbook.yml`
- `python3 -m doc8 -e .yaml releasenotes/notes/fix-start-order-services-ec1375f4c3470e1a.yaml`
- `python3 -m molecule test -s service_start_order_no_unit` *(fails: Failed to find driver delegated)*

------
https://chatgpt.com/codex/tasks/task_e_68948e20f1908327ba07a4c875de99fc