### PR TITLE
Fix Podman start-order unit detection and generation

### DIFF
--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -2,6 +2,9 @@
 # Default start priority for compute node services
 kolla_service_unit_prefix: "{{ 'container-' if kolla_container_engine == 'podman' else 'kolla-' }}"
 kolla_service_unit_suffix: "{{ '' if kolla_container_engine == 'podman' else '-container' }}"
+kolla_service_unit_search_paths:
+  - /etc/systemd/system
+  - /usr/lib/systemd/system
 kolla_service_start_wait_seconds: 45
 kolla_service_start_priority:
   - kolla_toolbox

--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -2,13 +2,39 @@
 - name: Detect services with systemd units
   become: true
   stat:
-    path: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
-  loop: "{{ kolla_service_start_priority }}"
+    path: "{{ item.0 }}/{{ kolla_service_unit_prefix }}{{ item.1 }}{{ kolla_service_unit_suffix }}.service"
+  loop: "{{ kolla_service_unit_search_paths | product(kolla_service_start_priority) | list }}"
   register: service_units
 
 - name: Build list of services with systemd units
   set_fact:
-    start_order_services: "{{ service_units.results | json_query('[?stat.exists].item') }}"
+    start_order_services: "{{ service_units.results | json_query('[?stat.exists].item.1') | unique }}"
+
+- name: Gather running containers
+  become: true
+  command: "{{ kolla_container_engine }} ps --format '{{ '{{.Names}}' }}'"
+  register: start_order_containers
+  changed_when: false
+
+- name: Determine services missing systemd units
+  set_fact:
+    missing_unit_services: "{{ start_order_containers.stdout_lines | intersect(kolla_service_start_priority) | difference(start_order_services) }}"
+
+- name: Generate systemd units for containers lacking them
+  become: true
+  command: "{{ kolla_container_engine }} generate systemd --name {{ item }} --files --new"
+  args:
+    chdir: /etc/systemd/system
+  loop: "{{ missing_unit_services }}"
+  when:
+    - kolla_container_engine == 'podman'
+    - missing_unit_services | length > 0
+  notify: Reload systemd
+
+- name: Update start order services with generated units
+  set_fact:
+    start_order_services: "{{ start_order_services + missing_unit_services }}"
+  when: missing_unit_services | length > 0
 
 - name: Build start order pairs
   set_fact:

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -9,7 +9,14 @@
   become: true
   stat:
     path: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
-  register: service_unit
+  register: service_unit_etc
+
+- name: Check if {{ item }} unit file exists in /usr/lib
+  become: true
+  stat:
+    path: "/usr/lib/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+  register: service_unit_usr
+  when: not service_unit_etc.stat.exists
 
 - name: Start {{ item }} service
   become: true
@@ -19,7 +26,7 @@
     enabled: true
   when:
     - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
-    - service_unit.stat.exists
+    - service_unit_etc.stat.exists or service_unit_usr.stat.exists | default(false)
 
 - name: Wait for neutron_ovs_cleanup to finish
   become: true
@@ -33,5 +40,5 @@
   until: cleanup_state.states.neutron_ovs_cleanup != 'running'
   when:
     - item == 'neutron_ovs_cleanup'
-    - service_unit.stat.exists
+    - service_unit_etc.stat.exists or service_unit_usr.stat.exists | default(false)
     - not ovs_cleanup_marker.stat.exists | default(false)

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -27,6 +27,12 @@ service starts regardless. This ensures dependencies such as databases and
 messaging back ends are available before the corresponding API services are
 launched.
 
+Unit files may be supplied either in ``/usr/lib/systemd/system`` or
+``/etc/systemd/system``. If a running container lacks a unit file,
+``service-start-order`` generates one using ``podman generate systemd`` and
+installs it under ``/etc/systemd/system`` before applying the start-order
+overrides.
+
 One-shot cleanup containers
 ---------------------------
 

--- a/doc/source/reference/podman.rst
+++ b/doc/source/reference/podman.rst
@@ -6,21 +6,16 @@ Some Kolla Ansible containers may be started outside of systemd and therefore
 lack a corresponding ``container-<name>.service`` unit. A common example is
 ``kolla_toolbox``, which is launched during bootstrap and left running.
 
-The ``service-check-containers`` and ``service-start-order`` roles verify and
-start containers via their systemd units. When using Podman, these roles check
-for the presence of a unit file before attempting any systemd operation. If no
-unit file is found, systemd actions are skipped and the container is assumed to
-be running as-is.
-
-.. note::
-
-   This behaviour ensures deployments succeed even when containers such as
-   ``kolla_toolbox`` are running without a systemd unit, both during service
-   checks and while applying start-order sequencing.
+The ``service-check-containers`` and ``service-start-order`` roles manage
+containers through their systemd units. Unit files may reside in either
+``/etc/systemd/system`` or ``/usr/lib/systemd/system`` and are detected in both
+locations. If a running container lacks a unit file, ``service-start-order``
+uses ``podman generate systemd`` to create one in ``/etc/systemd/system`` and
+reloads systemd.
 
 When unit files are present, the ``service-start-order`` role waits for the
 previous container to report a ``healthy`` state via
-``podman inspect --format '{{.State.Health.Status}}'`` before starting the
-next service. If the check does not report ``healthy`` within
+``podman inspect --format '{{.State.Health.Status}}'`` before starting the next
+service. If the check does not report ``healthy`` within
 ``kolla_service_start_wait_seconds`` seconds (45 by default), the startup
 continues.

--- a/molecule/service_start_order/playbook.yml
+++ b/molecule/service_start_order/playbook.yml
@@ -44,7 +44,7 @@
     - name: Create systemd unit for c1
       become: true
       copy:
-        dest: /etc/systemd/system/container-c1.service
+        dest: /usr/lib/systemd/system/container-c1.service
         content: |
           [Unit]
           Description=c1
@@ -58,7 +58,7 @@
     - name: Create systemd unit for c2
       become: true
       copy:
-        dest: /etc/systemd/system/container-c2.service
+        dest: /usr/lib/systemd/system/container-c2.service
         content: |
           [Unit]
           Description=c2

--- a/molecule/service_start_order/verify.yml
+++ b/molecule/service_start_order/verify.yml
@@ -21,10 +21,36 @@
           - "'State.Health.Status' in content"
           - "'-lt 5' in content"
 
+    - name: Stop services to simulate reboot
+      become: true
+      command: systemctl stop container-c2.service container-c1.service
+      changed_when: false
+
+    - name: Record start time
+      command: date +%s
+      register: start_ts
+      changed_when: false
+
+    - name: Start c2 service
+      become: true
+      command: systemctl start container-c2.service
+      changed_when: false
+
+    - name: Record end time
+      command: date +%s
+      register: end_ts
+      changed_when: false
+
     - name: Get c1 health status
       become: true
       command: podman inspect --format '{{.State.Health.Status}}' c1
       register: c1_health
+      changed_when: false
+
+    - name: Check c1 service status
+      become: true
+      command: systemctl is-active container-c1.service
+      register: c1_status
       changed_when: false
 
     - name: Check c2 service status
@@ -33,8 +59,10 @@
       register: c2_status
       changed_when: false
 
-    - name: Assert c2 started despite c1 being unhealthy
+    - name: Assert sequential start with health wait
       assert:
         that:
+          - end_ts.stdout | int - start_ts.stdout | int >= 5
           - c1_health.stdout != 'healthy'
+          - c1_status.stdout == 'active'
           - c2_status.stdout == 'active'

--- a/molecule/service_start_order_no_unit/playbook.yml
+++ b/molecule/service_start_order_no_unit/playbook.yml
@@ -30,7 +30,14 @@
       include_role:
         name: service-start-order
 
-    - name: Assert start_order_services is defined and empty
+    - name: Check generated unit file
+      become: true
+      stat:
+        path: /etc/systemd/system/container-kolla_toolbox.service
+      register: toolbox_unit
+
+    - name: Assert service detected and unit created
       assert:
         that:
-          - start_order_services == []
+          - start_order_services == ['kolla_toolbox']
+          - toolbox_unit.stat.exists

--- a/molecule/service_start_order_no_unit/verify.yml
+++ b/molecule/service_start_order_no_unit/verify.yml
@@ -7,13 +7,13 @@
       become: true
       command: podman container exists kolla_toolbox
 
-    - name: Check no systemd unit exists
+    - name: Check generated systemd unit exists
       become: true
       stat:
         path: /etc/systemd/system/container-kolla_toolbox.service
       register: toolbox_unit
 
-    - name: Fail if unit exists
-      fail:
-        msg: "Unit should not exist"
-      when: toolbox_unit.stat.exists
+    - name: Assert unit created
+      assert:
+        that:
+          - toolbox_unit.stat.exists

--- a/releasenotes/notes/podman-start-order-unit-detection-872b5901dffe9da0.yaml
+++ b/releasenotes/notes/podman-start-order-unit-detection-872b5901dffe9da0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The ``service-start-order`` role now detects Podman systemd unit files
+    in ``/usr/lib/systemd/system`` and generates missing units for running
+    containers. Drop-in configuration includes a health-check wait to
+    ensure sequential startup.


### PR DESCRIPTION
## Summary
- detect systemd units for services in /usr/lib as well as /etc
- generate missing systemd units for running containers and wait for health before starting dependents
- document Podman unit detection and add Molecule coverage

## Testing
- `pre-commit run --files ansible/roles/service-start-order/defaults/main.yml ansible/roles/service-start-order/tasks/deploy.yml ansible/roles/service-start-order/tasks/start_service.yml doc/source/reference/podman.rst doc/source/admin/podman.rst molecule/service_start_order/playbook.yml molecule/service_start_order/verify.yml molecule/service_start_order_no_unit/playbook.yml molecule/service_start_order_no_unit/verify.yml releasenotes/notes/podman-start-order-unit-detection-872b5901dffe9da0.yaml` *(failed: .pre-commit-config.yaml is not a file)*
- `tox -e linters` *(interrupted: exit -15)*
- `molecule test -s service_start_order` *(failed: driver delegated not found)*
- `molecule test -s service_start_order_no_unit` *(failed: driver delegated not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a78f6f488327bf23e7509b706300