### PR TITLE
Fix service-start-order unit detection

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -8,7 +8,7 @@
 
 - name: Build list of services with systemd units
   set_fact:
-    start_order_services: "{{ service_units.results | json_query('[?stat.exists].item.1') | unique }}"
+    start_order_services: "{{ service_units.results | json_query('[?stat.exists].item[1]') | unique }}"
 
 - name: Gather running containers
   become: true

--- a/molecule/service_start_order/playbook.yml
+++ b/molecule/service_start_order/playbook.yml
@@ -72,3 +72,8 @@
     - name: Run service-start-order role
       include_role:
         name: service-start-order
+
+    - name: Assert services detected
+      assert:
+        that:
+          - start_order_services == ['c1', 'c2']

--- a/releasenotes/notes/fix-service-start-order-jmespath-7d899984d6e0e6cc.yaml
+++ b/releasenotes/notes/fix-service-start-order-jmespath-7d899984d6e0e6cc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Correct the JMESPath query in the ``service-start-order`` role so
+    that systemd unit detection works with multiple search paths.


### PR DESCRIPTION
## Summary
- fix JMESPath query when detecting service units in service-start-order role
- assert expected start_order_services in service_start_order molecule scenario
- document fix in release notes

## Testing
- `tox -e linters` *(fails: 21 failure(s))*
- `tox -e py3` *(fails: docker dimension unit [e] is not supported)*
- `molecule test -s service_start_order` *(fails: driver delegated not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ab99086883279884bcd614f2f76e