### PR TITLE
service-start-order: support REST-created Podman containers

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -22,14 +22,33 @@
 
 - name: Generate systemd units for containers lacking them
   become: true
-  command: "{{ kolla_container_engine }} generate systemd --name {{ item }} --files --new"
-  args:
-    chdir: /etc/systemd/system
+  block:
+    - name: Generate systemd unit with create command
+      command: "{{ kolla_container_engine }} generate systemd --name {{ item }} --files --new"
+      args:
+        chdir: /etc/systemd/system
+      register: podman_generate
+      failed_when: podman_generate.rc not in [0, 125]
+      changed_when: podman_generate.rc == 0
+      notify: Reload systemd
+
+    - name: Generate systemd unit without create command
+      command: "{{ kolla_container_engine }} generate systemd --name {{ item }} --files"
+      args:
+        chdir: /etc/systemd/system
+      when: podman_generate.rc == 125
+      register: podman_generate_fallback
+      changed_when: podman_generate_fallback.rc == 0
+      notify: Reload systemd
+
+    - name: Fail if systemd unit generation failed
+      when: podman_generate.rc not in [0, 125] or (podman_generate.rc == 125 and podman_generate_fallback.rc != 0)
+      fail:
+        msg: "podman generate systemd failed for {{ item }}"
   loop: "{{ missing_unit_services }}"
   when:
     - kolla_container_engine == 'podman'
     - missing_unit_services | length > 0
-  notify: Reload systemd
 
 - name: Update start order services with generated units
   set_fact:

--- a/doc/source/reference/podman.rst
+++ b/doc/source/reference/podman.rst
@@ -11,7 +11,10 @@ containers through their systemd units. Unit files may reside in either
 ``/etc/systemd/system`` or ``/usr/lib/systemd/system`` and are detected in both
 locations. If a running container lacks a unit file, ``service-start-order``
 uses ``podman generate systemd`` to create one in ``/etc/systemd/system`` and
-reloads systemd.
+reloads systemd.  Containers started via the Podman REST API do not store a
+``CreateCommand`` and Podman ``generate systemd --new`` rejects them.  The role
+attempts generation with ``--new`` first and falls back to generating a unit
+without it so that both CLI- and REST-created containers receive systemd units.
 
 When unit files are present, the ``service-start-order`` role waits for the
 previous container to report a ``healthy`` state via

--- a/molecule/service_start_order/playbook.yml
+++ b/molecule/service_start_order/playbook.yml
@@ -25,6 +25,17 @@
       - c1
       - c2
   tasks:
+    - name: Start Podman REST API service
+      become: true
+      shell: podman system service --time=0 &
+      changed_when: false
+
+    - name: Wait for Podman REST socket
+      become: true
+      wait_for:
+        path: /run/podman/podman.sock
+        timeout: 5
+
     - name: Ensure c1 container is running
       become: true
       command: >-
@@ -33,10 +44,10 @@
       changed_when: c1_run.rc == 0
       failed_when: c1_run.rc not in [0,125]
 
-    - name: Ensure c2 container is running
+    - name: Ensure c2 container is running via REST
       become: true
       command: >-
-        podman run -d --name c2 --health-cmd 'true' --health-interval 1s docker.io/library/busybox:latest tail -f /dev/null
+        podman --url unix:///run/podman/podman.sock run -d --name c2 --health-cmd 'true' --health-interval 1s docker.io/library/busybox:latest tail -f /dev/null
       register: c2_run
       changed_when: c2_run.rc == 0
       failed_when: c2_run.rc not in [0,125]
@@ -51,20 +62,6 @@
           [Service]
           ExecStart=/usr/bin/podman start -a c1
           ExecStop=/usr/bin/podman stop -t 10 c1
-          Restart=always
-          [Install]
-          WantedBy=multi-user.target
-
-    - name: Create systemd unit for c2
-      become: true
-      copy:
-        dest: /usr/lib/systemd/system/container-c2.service
-        content: |
-          [Unit]
-          Description=c2
-          [Service]
-          ExecStart=/usr/bin/podman start -a c2
-          ExecStop=/usr/bin/podman stop -t 10 c2
           Restart=always
           [Install]
           WantedBy=multi-user.target

--- a/releasenotes/notes/service-start-order-podman-fallback-b7d1aa7b0a4d9b74.yaml
+++ b/releasenotes/notes/service-start-order-podman-fallback-b7d1aa7b0a4d9b74.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The ``service-start-order`` role now handles Podman containers created via
+    the REST API that lack a stored ``CreateCommand``.  It first attempts
+    ``podman generate systemd --new`` and falls back to generating without
+    ``--new`` so that units are created for all running containers.


### PR DESCRIPTION
## Summary
- handle Podman containers that lack CreateCommand by trying `podman generate systemd --new` and falling back without `--new`
- document Podman REST container support for service-start-order
- extend service_start_order molecule scenario to cover REST-created container

## Testing
- `tox -e linters` (fails: Rule violations)
- `tox -e py3` (fails: TestResult has no addDuration method, exit 1)
- `molecule test -s service_start_order` (fails: driver delegated not found)


------
https://chatgpt.com/codex/tasks/task_e_6894b045b1fc83279f21523c571c86ae