### PR TITLE
Fix systemd unit generation loop in service-start-order role

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -22,30 +22,10 @@
 
 - name: Generate systemd units for containers lacking them
   become: true
-  block:
-    - name: Generate systemd unit with create command
-      command: "{{ kolla_container_engine }} generate systemd --name {{ item }} --files --new"
-      args:
-        chdir: /etc/systemd/system
-      register: podman_generate
-      failed_when: podman_generate.rc not in [0, 125]
-      changed_when: podman_generate.rc == 0
-      notify: Reload systemd
-
-    - name: Generate systemd unit without create command
-      command: "{{ kolla_container_engine }} generate systemd --name {{ item }} --files"
-      args:
-        chdir: /etc/systemd/system
-      when: podman_generate.rc == 125
-      register: podman_generate_fallback
-      changed_when: podman_generate_fallback.rc == 0
-      notify: Reload systemd
-
-    - name: Fail if systemd unit generation failed
-      when: podman_generate.rc not in [0, 125] or (podman_generate.rc == 125 and podman_generate_fallback.rc != 0)
-      fail:
-        msg: "podman generate systemd failed for {{ item }}"
+  include_tasks: generate_unit.yml
   loop: "{{ missing_unit_services }}"
+  loop_control:
+    loop_var: service
   when:
     - kolla_container_engine == 'podman'
     - missing_unit_services | length > 0

--- a/ansible/roles/service-start-order/tasks/generate_unit.yml
+++ b/ansible/roles/service-start-order/tasks/generate_unit.yml
@@ -1,0 +1,25 @@
+---
+- name: Generate systemd unit with create command
+  become: true
+  command: "{{ kolla_container_engine }} generate systemd --name {{ service }} --files --new"
+  args:
+    chdir: /etc/systemd/system
+  register: podman_generate
+  failed_when: podman_generate.rc not in [0, 125]
+  changed_when: podman_generate.rc == 0
+  notify: Reload systemd
+
+- name: Generate systemd unit without create command
+  become: true
+  command: "{{ kolla_container_engine }} generate systemd --name {{ service }} --files"
+  args:
+    chdir: /etc/systemd/system
+  when: podman_generate.rc == 125
+  register: podman_generate_fallback
+  changed_when: podman_generate_fallback.rc == 0
+  notify: Reload systemd
+
+- name: Fail if systemd unit generation failed
+  when: podman_generate.rc not in [0, 125] or (podman_generate.rc == 125 and podman_generate_fallback.rc != 0)
+  fail:
+    msg: "podman generate systemd failed for {{ service }}"

--- a/releasenotes/notes/fix-service-start-order-block-loop.yaml
+++ b/releasenotes/notes/fix-service-start-order-block-loop.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Corrects the systemd unit generation in the service-start-order
+    role by iterating over containers without units properly.
+    This allows missing unit files to be generated and ensures the
+    playbook continues after processing each container.
+


### PR DESCRIPTION
## Summary
- ensure service-start-order iterates over missing units when generating systemd files
- document fix in release notes

## Testing
- `tox -e linters` *(fails: 21 failure(s), including duplicate dict keys and YAML formatting)*
- `ansible-lint ansible/roles/service-start-order/tasks/deploy.yml ansible/roles/service-start-order/tasks/generate_unit.yml`
- `molecule test -s service_start_order_no_unit` *(fails: Failed to find driver delegated)*
- `ansible-playbook molecule/service_start_order_no_unit/playbook.yml` *(fails: podman run operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_6894b4b5f72c8327b7474698c46a09b8