### PR TITLE
service-start-order: remove invalid become from unit generation

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -21,7 +21,6 @@
     missing_unit_services: "{{ start_order_containers.stdout_lines | intersect(kolla_service_start_priority) | difference(start_order_services) }}"
 
 - name: Generate systemd units for containers lacking them
-  become: true
   include_tasks: generate_unit.yml
   loop: "{{ missing_unit_services }}"
   loop_control:


### PR DESCRIPTION
## Summary
- fix syntax error by removing invalid `become` from dynamic include in service-start-order

## Testing
- `ansible-lint ansible/roles/service-start-order/tasks/deploy.yml`

------
https://chatgpt.com/codex/tasks/task_e_6894b8de1168832781941f5c09929b4f