### PR TITLE
Fix service start order cycle detection

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -8,7 +8,7 @@
 
 - name: Build list of services with systemd units
   set_fact:
-    start_order_services: "{{ service_units.results | json_query('[?stat.exists].item[1]') | unique }}"
+    existing_unit_services: "{{ service_units.results | json_query('[?stat.exists].item[1]') | unique }}"
 
 - name: Gather running containers
   become: true
@@ -18,21 +18,20 @@
 
 - name: Determine services missing systemd units
   set_fact:
-    missing_unit_services: "{{ start_order_containers.stdout_lines | intersect(kolla_service_start_priority) | difference(start_order_services) }}"
+    missing_unit_services: "{{ kolla_service_start_priority | difference(existing_unit_services) | intersect(start_order_containers.stdout_lines) }}"
 
 - name: Generate systemd units for containers lacking them
   include_tasks: generate_unit.yml
   loop: "{{ missing_unit_services }}"
   loop_control:
-    loop_var: service
+    loop_var: service_name
   when:
     - kolla_container_engine == 'podman'
     - missing_unit_services | length > 0
 
-- name: Update start order services with generated units
+- name: Build start order services
   set_fact:
-    start_order_services: "{{ start_order_services + missing_unit_services }}"
-  when: missing_unit_services | length > 0
+    start_order_services: "{{ kolla_service_start_priority | select('in', existing_unit_services + missing_unit_services) | list }}"
 
 - name: Build start order pairs
   set_fact:
@@ -54,6 +53,16 @@
     mode: "0644"
   loop: "{{ start_order_pairs }}"
   notify: Reload systemd
+
+- name: Detect systemd dependency cycles
+  become: true
+  command: "systemd-analyze verify {{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+  loop: "{{ start_order_services }}"
+  loop_control:
+    label: "{{ item }}"
+  changed_when: false
+  register: cycle_check
+  failed_when: cycle_check.stderr is search('Cycle')
 
 - name: Start compute services in order
   include_tasks: start_service.yml

--- a/ansible/roles/service-start-order/tasks/generate_unit.yml
+++ b/ansible/roles/service-start-order/tasks/generate_unit.yml
@@ -1,7 +1,7 @@
 ---
 - name: Generate systemd unit with create command
   become: true
-  command: "{{ kolla_container_engine }} generate systemd --name {{ service }} --files --new"
+  command: "{{ kolla_container_engine }} generate systemd --name {{ service_name }} --files --new"
   args:
     chdir: /etc/systemd/system
   register: podman_generate
@@ -11,7 +11,7 @@
 
 - name: Generate systemd unit without create command
   become: true
-  command: "{{ kolla_container_engine }} generate systemd --name {{ service }} --files"
+  command: "{{ kolla_container_engine }} generate systemd --name {{ service_name }} --files"
   args:
     chdir: /etc/systemd/system
   when: podman_generate.rc == 125
@@ -22,4 +22,4 @@
 - name: Fail if systemd unit generation failed
   when: podman_generate.rc not in [0, 125] or (podman_generate.rc == 125 and podman_generate_fallback.rc != 0)
   fail:
-    msg: "podman generate systemd failed for {{ service }}"
+    msg: "podman generate systemd failed for {{ service_name }}"

--- a/doc/source/reference/podman.rst
+++ b/doc/source/reference/podman.rst
@@ -21,4 +21,6 @@ previous container to report a ``healthy`` state via
 ``podman inspect --format '{{.State.Health.Status}}'`` before starting the next
 service. If the check does not report ``healthy`` within
 ``kolla_service_start_wait_seconds`` seconds (45 by default), the startup
-continues.
+continues. To prevent deadlocks at boot the role also verifies that the
+resulting systemd dependency graph is acyclic by running
+``systemd-analyze verify`` on the generated units.

--- a/molecule/service_start_order/verify.yml
+++ b/molecule/service_start_order/verify.yml
@@ -21,6 +21,13 @@
           - "'State.Health.Status' in content"
           - "'-lt 5' in content"
 
+    - name: Verify no dependency cycles
+      become: true
+      command: systemd-analyze verify container-c1.service container-c2.service
+      register: verify_cycles
+      changed_when: false
+      failed_when: "'Cycle in' in verify_cycles.stderr"
+
     - name: Stop services to simulate reboot
       become: true
       command: systemctl stop container-c2.service container-c1.service

--- a/molecule/service_start_order_cycle/molecule.yml
+++ b/molecule/service_start_order_cycle/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/service_start_order_cycle/playbook.yml
+++ b/molecule/service_start_order_cycle/playbook.yml
@@ -1,0 +1,69 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:  # noqa var-naming[read-only]
+      control:
+        - localhost
+    project_name: testsowait
+    testsowait_services:
+      c1:
+        container_name: c1
+        group: control
+        enabled: true
+        image: docker.io/library/busybox:latest
+      c2:
+        container_name: c2
+        group: control
+        enabled: true
+        image: docker.io/library/busybox:latest
+    kolla_container_engine: podman
+    docker_common_options: {}
+    kolla_service_start_wait_seconds: 5
+    kolla_service_start_priority:
+      - c1
+      - c2
+  tasks:
+    - name: Ensure c1 container is running
+      become: true
+      command: >-
+        podman run -d --name c1 docker.io/library/busybox:latest tail -f /dev/null
+      register: c1_run
+      changed_when: c1_run.rc == 0
+      failed_when: c1_run.rc not in [0,125]
+
+    - name: Ensure c2 container is running
+      become: true
+      command: >-
+        podman run -d --name c2 docker.io/library/busybox:latest tail -f /dev/null
+      register: c2_run
+      changed_when: c2_run.rc == 0
+      failed_when: c2_run.rc not in [0,125]
+
+    - name: Create systemd unit for c1 with dependency on c2
+      become: true
+      copy:
+        dest: /usr/lib/systemd/system/container-c1.service
+        content: |
+          [Unit]
+          Description=c1
+          Requires=container-c2.service
+          After=container-c2.service
+          [Service]
+          ExecStart=/usr/bin/podman start -a c1
+          ExecStop=/usr/bin/podman stop -t 10 c1
+          Restart=always
+          [Install]
+          WantedBy=multi-user.target
+
+    - block:
+        - name: Run service-start-order role
+          include_role:
+            name: service-start-order
+      rescue:
+        - set_fact:
+            cycle_detected: true
+      always:
+        - assert:
+            that: cycle_detected | default(false)

--- a/molecule/service_start_order_cycle/verify.yml
+++ b/molecule/service_start_order_cycle/verify.yml
@@ -1,0 +1,4 @@
+---
+- hosts: localhost
+  gather_facts: false
+  tasks: []

--- a/releasenotes/notes/service-start-order-cycle-detection.yaml
+++ b/releasenotes/notes/service-start-order-cycle-detection.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    The ``service-start-order`` role now preserves the user-defined start
+    priority when generating drop-ins and detects systemd dependency cycles
+    using ``systemd-analyze verify``.
+fixes:
+  - |
+    Resolved a bug where missing systemd units were appended out of order,
+    leading to cyclic ``After``/``Requires`` chains and failed starts.


### PR DESCRIPTION
## Summary
- preserve user-defined priority when generating service drop-ins
- detect systemd dependency cycles to avoid deadlocks
- test start-order role against cyclic dependencies

## Testing
- `tools/pre-commit-hook` (fails: Missing parentheses in call to 'print')
- `find . -name '*.yaml' -o -name '*.yml' -print0 | xargs -0 python3 tools/validate-yaml.py`
- `molecule test -s service_start_order` (fails: driver delegated not found)


------
https://chatgpt.com/codex/tasks/task_e_6894bf5badd483279f2cc99953626376