### PR TITLE
Handle missing container units

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -38,7 +38,7 @@
   when:
     - not container_needs_recreate | bool
     - runtime_restart.rc != 0
-
+    - unit_file.stat.isreg | default(false)
 - name: Restart unit as fallback
   listen: Restart container
   become: true
@@ -48,4 +48,4 @@
   when:
     - not container_needs_recreate | bool
     - runtime_restart.rc != 0
-
+    - unit_file.stat.isreg | default(false)

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -56,11 +56,11 @@
   register: unit_enabled_res
   changed_when: false
   failed_when: false
-  when: unit_file.stat.exists
+  when: unit_file.stat.isreg | default(false)
 
 - name: Set unit enabled fact
   set_fact:
-    unit_enabled: "{{ unit_file.stat.exists and (unit_enabled_res.rc | default(1)) == 0 }}"
+    unit_enabled: "{{ unit_file.stat.isreg | default(false) and (unit_enabled_res.rc | default(1)) == 0 }}"
 
 - name: Check unit active
   become: true
@@ -68,14 +68,14 @@
   register: unit_active
   changed_when: false
   failed_when: false
-  when: unit_file.stat.exists
+  when: unit_file.stat.isreg | default(false)
 
 - name: Record container and unit status
   set_fact:
     container_missing: "{{ container_result.rc != 0 }}"
     unit_missing_or_disabled: "{{ not unit_enabled }}"
     needs_start: >-
-      {{ container_result.rc != 0 or (unit_file.stat.exists and (not unit_enabled or unit_active.rc | default(3) != 0)) }}
+      {{ container_result.rc != 0 or (unit_file.stat.isreg | default(false) and (not unit_enabled or unit_active.rc | default(3) != 0)) }}
 
 - name: Detect health-check drift
   set_fact:
@@ -117,5 +117,5 @@
     enabled: true
   when:
     - not container_missing
-    - unit_file.stat.exists
+    - unit_file.stat.isreg | default(false)
     - (unit_active.rc | default(0)) != 0

--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -25,6 +25,9 @@
   loop: "{{ missing_unit_services }}"
   loop_control:
     loop_var: service_name
+    label: "{{ service_name }}"
+  vars:
+    service_name: "{{ service_name }}"
   when:
     - kolla_container_engine == 'podman'
     - missing_unit_services | length > 0

--- a/molecule/service_check_start_order_no_unit/molecule.yml
+++ b/molecule/service_check_start_order_no_unit/molecule.yml
@@ -1,0 +1,16 @@
+dependency:
+  name: galaxy
+driver:
+  name: default
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/service_check_start_order_no_unit/playbook.yml
+++ b/molecule/service_check_start_order_no_unit/playbook.yml
@@ -1,0 +1,35 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:  # noqa var-naming[read-only]
+      control:
+        - localhost
+    project_name: testscsun
+    testscsun_services:
+      toolbox:
+        container_name: kolla_toolbox
+        group: control
+        enabled: true
+        image: docker.io/library/busybox:latest
+    kolla_container_engine: podman
+    docker_common_options: {}
+    kolla_service_start_priority:
+      - kolla_toolbox
+  tasks:
+    - name: Ensure kolla_toolbox container is running without unit
+      become: true
+      command: >-
+        podman run -d --name kolla_toolbox docker.io/library/busybox:latest tail -f /dev/null
+      register: toolbox_run
+      changed_when: toolbox_run.rc == 0
+      failed_when: toolbox_run.rc not in [0,125]
+
+    - name: Run service-check-containers role
+      include_role:
+        name: service-check-containers
+
+    - name: Run service-start-order role
+      include_role:
+        name: service-start-order

--- a/molecule/service_check_start_order_no_unit/verify.yml
+++ b/molecule/service_check_start_order_no_unit/verify.yml
@@ -1,0 +1,15 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check generated unit file
+      become: true
+      stat:
+        path: /etc/systemd/system/container-kolla_toolbox.service
+      register: toolbox_unit
+
+    - name: Assert unit created
+      assert:
+        that:
+          - toolbox_unit.stat.isreg

--- a/releasenotes/notes/service-check-skip-missing-units-0db7a2b4e7b2e22d.yaml
+++ b/releasenotes/notes/service-check-skip-missing-units-0db7a2b4e7b2e22d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ``service-check-containers`` no longer attempts to enable or restart
+    systemd units when the unit file is absent, preventing failures on
+    clean hosts where units have not yet been generated. A new Molecule
+    test covers this scenario.


### PR DESCRIPTION
## Summary
- avoid enabling or restarting systemd units when unit file is absent
- fix service-start-order loop warnings and add a Molecule scenario for missing units

## Testing
- `ansible-lint ansible/roles/service-check-containers/tasks/verify.yml ansible/roles/service-check-containers/handlers/main.yml ansible/roles/service-start-order/tasks/deploy.yml molecule/service_check_start_order_no_unit/playbook.yml molecule/service_check_start_order_no_unit/verify.yml` (failed: jinja profile:basic tags:formatting)
- `molecule test -s service_check_start_order_no_unit` (failed: podman: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_6894c4562d4883278bb79516e438c4b8