### PR TITLE
openvswitch: wait for db socket before configuring

### DIFF
--- a/ansible/roles/openvswitch/defaults/main.yml
+++ b/ansible/roles/openvswitch/defaults/main.yml
@@ -105,3 +105,4 @@ openvswitch_ovs_vsctl_wrapper_enabled: false
 openvswitch_system_id: "{{ ansible_facts.hostname }}"
 openvswitch_hostname: "{{ ansible_facts.fqdn }}"
 openvswitch_hw_offload: "no"
+openvswitch_db_ready_timeout: 45

--- a/ansible/roles/openvswitch/tasks/post-config.yml
+++ b/ansible/roles/openvswitch/tasks/post-config.yml
@@ -1,5 +1,15 @@
 ---
 # NOTE(mnasiadka): external_ids:system-id uniquely identifies a physical system, used by OVN and other controllers
+- name: Wait for openvswitch db socket
+  become: true
+  wait_for:
+    path: /var/run/openvswitch/db.sock
+    state: started
+    timeout: "{{ openvswitch_db_ready_timeout }}"
+  when:
+    - openvswitch_services['openvswitch-vswitchd'].host_in_groups | bool
+  changed_when: false
+
 - name: Set system-id, hostname and hw-offload
   become: true
   kolla_toolbox:
@@ -9,14 +19,16 @@
     module_args:
       table: Open_vSwitch
       record: .
-      col: "{{ item.col }}"
-      key: "{{ item.name }}"
-      value: "{{ item.value }}"
-      state: "{{ item.state | default('present') }}"
+      col: "{{ ovsdb_item.col }}"
+      key: "{{ ovsdb_item.name }}"
+      value: "{{ ovsdb_item.value }}"
+      state: "{{ ovsdb_item.state | default('present') }}"
   loop:
     - { col: "external_ids", name: "system-id", value: "{{ openvswitch_system_id }}" }
     - { col: "external_ids", name: "hostname", value: "{{ openvswitch_hostname }}" }
     - { col: "other_config", name: "hw-offload", value: true, state: "{{ 'present' if openvswitch_hw_offload | bool else 'absent' }}" }
+  loop_control:
+    loop_var: ovsdb_item
   when:
     - openvswitch_services['openvswitch-vswitchd'].host_in_groups | bool
   notify:

--- a/molecule/openvswitch-db-wait/molecule.yml
+++ b/molecule/openvswitch-db-wait/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/openvswitch-db-wait/playbook.yml
+++ b/molecule/openvswitch-db-wait/playbook.yml
@@ -1,0 +1,31 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: true
+  vars:
+    openvswitch_db_ready_timeout: 45
+  tasks:
+    - name: Install Open vSwitch
+      become: true
+      package:
+        name: openvswitch-switch
+        state: present
+
+    - name: Start Open vSwitch
+      become: true
+      command: /usr/share/openvswitch/scripts/ovs-ctl start
+      changed_when: false
+
+    - name: Wait for Open vSwitch database socket
+      become: true
+      wait_for:
+        path: /var/run/openvswitch/db.sock
+        state: started
+        timeout: "{{ openvswitch_db_ready_timeout }}"
+      changed_when: false
+
+    - name: Configure system-id and hostname
+      become: true
+      command: >-
+        ovs-vsctl set Open_vSwitch . external_ids:system-id="$(hostname)" external_ids:hostname="$(hostname --fqdn)"
+      changed_when: false

--- a/molecule/openvswitch-db-wait/verify.yml
+++ b/molecule/openvswitch-db-wait/verify.yml
@@ -1,0 +1,14 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Get system-id
+      command: ovs-vsctl get Open_vSwitch . external_ids:system-id
+      register: system_id
+      changed_when: false
+
+    - name: Assert system-id matches hostname
+      assert:
+        that:
+          - system_id.stdout == ansible_facts.hostname

--- a/releasenotes/notes/openvswitch-db-wait-53f89d3d0d4e5a8a.yaml
+++ b/releasenotes/notes/openvswitch-db-wait-53f89d3d0d4e5a8a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Wait for the Open vSwitch database socket before configuring
+    system-id, hostname and hw-offload, preventing early failures on
+    fresh deployments where the OVSDB process is not yet ready.


### PR DESCRIPTION
## Summary
- wait for OVS database socket before setting external_ids
- add molecule test verifying ovs-vsctl system-id configuration

## Testing
- `tox -e linters` *(failed: template error from podman filter)*
- `molecule test -s openvswitch-db-wait` *(failed: AttributeError: 'Runtime' object has no attribute 'exec')*


------
https://chatgpt.com/codex/tasks/task_e_6894cae548ec83278a26cefe58a03c1d