### PR TITLE
openvswitch: configure after container start

### DIFF
--- a/ansible/roles/openvswitch/tasks/deploy.yml
+++ b/ansible/roles/openvswitch/tasks/deploy.yml
@@ -7,5 +7,3 @@
 
 - name: Flush Handlers
   meta: flush_handlers
-
-- import_tasks: post-config.yml

--- a/ansible/roles/openvswitch/tasks/post-deploy.yml
+++ b/ansible/roles/openvswitch/tasks/post-deploy.yml
@@ -1,14 +1,15 @@
 ---
 # NOTE(mnasiadka): external_ids:system-id uniquely identifies a physical system, used by OVN and other controllers
-- name: Wait for openvswitch db socket
+- name: Wait for openvswitch db service to be ready
   become: true
-  wait_for:
-    path: /var/run/openvswitch/db.sock
-    state: started
-    timeout: "{{ openvswitch_db_ready_timeout }}"
+  command: "{{ kolla_container_engine }} exec openvswitch_db ovs-vsctl --no-wait show"
+  register: check_result
+  until: check_result is success
+  retries: "{{ openvswitch_db_ready_timeout | int }}"
+  delay: 1
+  changed_when: false
   when:
     - openvswitch_services['openvswitch-vswitchd'].host_in_groups | bool
-  changed_when: false
 
 - name: Set system-id, hostname and hw-offload
   become: true

--- a/ansible/roles/openvswitch/tasks/upgrade.yml
+++ b/ansible/roles/openvswitch/tasks/upgrade.yml
@@ -7,5 +7,3 @@
 
 - name: Flush Handlers
   meta: flush_handlers
-
-- import_tasks: post-config.yml

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1060,3 +1060,22 @@
   roles:
     - { role: service-start-order,
         tags: service-start-order }
+
+- name: Apply openvswitch post-configuration
+  gather_facts: false
+  hosts:
+    - openvswitch
+    - '&enable_openvswitch_True_enable_ovs_dpdk_False'
+  serial: '{{ kolla_serial|default("0") }}'
+  max_fail_percentage: >-
+    {{ openvswitch_max_fail_percentage |
+       default(kolla_max_fail_percentage) |
+       default(100) }}
+  tags:
+    - openvswitch
+  tasks:
+    - name: Include openvswitch post-deploy.yml
+      include_role:
+        name: openvswitch
+        tasks_from: post-deploy.yml
+      when: kolla_action in ['deploy', 'reconfigure', 'upgrade']

--- a/molecule/openvswitch-db-wait/playbook.yml
+++ b/molecule/openvswitch-db-wait/playbook.yml
@@ -16,16 +16,17 @@
       command: /usr/share/openvswitch/scripts/ovs-ctl start
       changed_when: false
 
-    - name: Wait for Open vSwitch database socket
+    - name: Wait for Open vSwitch database to be ready
       become: true
-      wait_for:
-        path: /var/run/openvswitch/db.sock
-        state: started
-        timeout: "{{ openvswitch_db_ready_timeout }}"
+      command: ovs-vsctl --no-wait show
+      register: ovsdb_check
+      until: ovsdb_check is success
+      retries: "{{ openvswitch_db_ready_timeout }}"
+      delay: 1
       changed_when: false
 
     - name: Configure system-id and hostname
       become: true
       command: >-
-        ovs-vsctl set Open_vSwitch . external_ids:system-id="$(hostname)" external_ids:hostname="$(hostname --fqdn)"
+        ovs-vsctl set Open_vSwitch . external_ids:system-id="{{ ansible_facts.hostname }}" external_ids:hostname="{{ ansible_facts.fqdn }}"
       changed_when: false

--- a/releasenotes/notes/openvswitch-post-start-fix-5b7d1b4da1fb66e9.yaml
+++ b/releasenotes/notes/openvswitch-post-start-fix-5b7d1b4da1fb66e9.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Resolved a failure in the ``openvswitch`` role when containers are
+    started at the end. Configuration of the Open vSwitch database now
+    waits for the ``openvswitch_db`` container to be running before
+    applying settings.


### PR DESCRIPTION
## Summary
- defer openvswitch database tweaks until container is running
- add post-start play and update molecule test
- document openvswitch start-order fix

## Testing
- `ansible-playbook molecule/openvswitch-db-wait/playbook.yml`
- `ansible-playbook molecule/openvswitch-db-wait/verify.yml`
- `tox -e linters` *(fails: 24 rule violations)*


------
https://chatgpt.com/codex/tasks/task_e_6894cffdc49483278da99399f9c9a142