### PR TITLE
Ensure deterministic container orchestration

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -20,6 +20,16 @@
   import_tasks: recreate.yml
   notify: Restart unit as fallback
 
+- name: Get container state
+  listen: Restart container
+  become: true
+  kolla_container_facts:
+    action: get_containers_state
+    container_engine: "{{ kolla_container_engine }}"
+    name: "{{ container_name }}"
+  register: restart_container_state
+  changed_when: false
+
 - name: Attempt runtime restart first
   listen: Restart container
   become: true
@@ -27,7 +37,9 @@
   register: runtime_restart
   failed_when: false
   changed_when: runtime_restart.rc == 0
-  when: not container_needs_recreate | bool
+  when:
+    - not container_needs_recreate | bool
+    - (restart_container_state.states[container_name] | default('')) == 'running'
 
 - name: Ensure unit enabled
   listen: Restart container
@@ -37,6 +49,7 @@
     enabled: true
   when:
     - not container_needs_recreate | bool
+    - (restart_container_state.states[container_name] | default('')) == 'running'
     - runtime_restart.rc != 0
     - unit_file.stat.isreg | default(false)
 - name: Restart unit as fallback
@@ -47,5 +60,6 @@
     state: restarted
   when:
     - not container_needs_recreate | bool
+    - (restart_container_state.states[container_name] | default('')) == 'running'
     - runtime_restart.rc != 0
     - unit_file.stat.isreg | default(false)

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -630,10 +630,6 @@
     - { role: ovn-db,
         tags: [ovn, ovn-db] }
 
-# Nova deployment is more complicated than other services, so is covered in its
-# own playbook.
-- import_playbook: nova.yml
-
 - name: Apply role neutron
   gather_facts: false
   hosts:
@@ -657,6 +653,10 @@
   roles:
     - { role: neutron,
         tags: neutron }
+
+# Nova deployment is more complicated than other services, so is covered in its
+# own playbook.
+- import_playbook: nova.yml
 
 - name: Apply role kuryr
   gather_facts: false


### PR DESCRIPTION
## Summary
- ensure restart handlers skip containers that are only created
- start nova services after neutron to preserve desired creation order

## Testing
- `ansible-lint ansible/site.yml ansible/roles/service-check-containers/handlers/main.yml`
- `tox -e linters` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6895dcabc5a48327bc00cf1baf890bcf