### PR TITLE
Handle missing containers in service check

### DIFF
--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -28,6 +28,7 @@
     container_engine: "{{ kolla_container_engine }}"
     name: "{{ container_name }}"
   register: restart_container_state
+  failed_when: false
   changed_when: false
 
 - name: Attempt runtime restart first
@@ -39,7 +40,7 @@
   changed_when: runtime_restart.rc == 0
   when:
     - not container_needs_recreate | bool
-    - (restart_container_state.states[container_name] | default('')) == 'running'
+    - ((restart_container_state.states | default({}))[container_name] | default('')) == 'running'
 
 - name: Ensure unit enabled
   listen: Restart container
@@ -49,7 +50,7 @@
     enabled: true
   when:
     - not container_needs_recreate | bool
-    - (restart_container_state.states[container_name] | default('')) == 'running'
+    - ((restart_container_state.states | default({}))[container_name] | default('')) == 'running'
     - runtime_restart.rc != 0
     - unit_file.stat.isreg | default(false)
 - name: Restart unit as fallback
@@ -60,6 +61,6 @@
     state: restarted
   when:
     - not container_needs_recreate | bool
-    - (restart_container_state.states[container_name] | default('')) == 'running'
+    - ((restart_container_state.states | default({}))[container_name] | default('')) == 'running'
     - runtime_restart.rc != 0
     - unit_file.stat.isreg | default(false)

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -104,7 +104,9 @@
     msg: Notifying restart handler
   changed_when: needs_start | bool and not container_needs_recreate | bool
   notify: "Restart container"
-  when: not container_needs_recreate | bool
+  when:
+    - not container_needs_recreate | bool
+    - not container_missing
 
 - name: Flush restart handler
   meta: flush_handlers

--- a/doc/source/reference/podman.rst
+++ b/doc/source/reference/podman.rst
@@ -16,6 +16,11 @@ reloads systemd.  Containers started via the Podman REST API do not store a
 attempts generation with ``--new`` first and falls back to generating a unit
 without it so that both CLI- and REST-created containers receive systemd units.
 
+When a service is not deployed on a host, and its container and corresponding
+systemd unit are absent or disabled, ``service-check-containers`` skips any
+restart or enablement attempts. This allows staged deployments where only a
+subset of services are present without causing unnecessary failures.
+
 When unit files are present, the ``service-start-order`` role waits for the
 previous container to report a ``healthy`` state via
 ``podman inspect --format '{{.State.Health.Status}}'`` before starting the next

--- a/molecule/service_check_unit_no_container/molecule.yml
+++ b/molecule/service_check_unit_no_container/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/service_check_unit_no_container/playbook.yml
+++ b/molecule/service_check_unit_no_container/playbook.yml
@@ -1,0 +1,40 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:  # noqa var-naming[read-only]
+      control:
+        - localhost
+    project_name: testnu
+    testnu_services:
+      toolbox:
+        container_name: kolla_toolbox
+        group: control
+        enabled: true
+        image: docker.io/library/busybox:latest
+    kolla_container_engine: podman
+    docker_common_options: {}
+  tasks:
+    - name: Ensure kolla_toolbox container is absent
+      become: true
+      command: podman rm -f kolla_toolbox
+      register: toolbox_rm
+      changed_when: toolbox_rm.rc == 0
+      failed_when: toolbox_rm.rc not in [0,1,125]
+
+    - name: Create disabled unit file
+      become: true
+      copy:
+        dest: /etc/systemd/system/container-kolla_toolbox.service
+        content: |
+          [Unit]
+          Description=Dummy unit for kolla_toolbox
+          [Service]
+          Restart=always
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Run service-check-containers role
+      include_role:
+        name: service-check-containers

--- a/molecule/service_check_unit_no_container/verify.yml
+++ b/molecule/service_check_unit_no_container/verify.yml
@@ -1,0 +1,31 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Ensure container is absent
+      become: true
+      command: podman container exists kolla_toolbox
+      register: container_exists
+      failed_when: container_exists.rc == 0
+
+    - name: Check unit file exists
+      become: true
+      stat:
+        path: /etc/systemd/system/container-kolla_toolbox.service
+      register: toolbox_unit
+
+    - name: Assert unit file exists
+      assert:
+        that: toolbox_unit.stat.exists
+
+    - name: Check unit not enabled via symlink
+      become: true
+      stat:
+        path: /etc/systemd/system/multi-user.target.wants/container-kolla_toolbox.service
+      register: toolbox_wants
+
+    - name: Assert unit is not enabled
+      assert:
+        that:
+          - not toolbox_wants.stat.exists

--- a/releasenotes/notes/service-check-skip-absent-containers-7a2d1f1d72b7df.yaml
+++ b/releasenotes/notes/service-check-skip-absent-containers-7a2d1f1d72b7df.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The ``service-check-containers`` role no longer attempts to restart
+    services when the container is missing and the corresponding systemd unit
+    is disabled. The restart handler now tolerates absent containers,
+    preventing failures on hosts where a service has not yet been deployed.


### PR DESCRIPTION
## Summary
- avoid notifying restart handler when container is missing
- tolerate absent containers in restart handler
- document and test behavior on hosts without the service

## Testing
- `tox -e linters` *(fails: yaml[empty-lines], jinja invalid errors, var-naming read-only, internal errors)*
- `ansible-lint ansible/roles/service-check-containers/handlers/main.yml ansible/roles/service-check-containers/tasks/verify.yml molecule/service_check_unit_no_container/playbook.yml molecule/service_check_unit_no_container/verify.yml`
- `molecule test -s service_check_unit_no_container` *(fails: Failed to find driver delegated)*

------
https://chatgpt.com/codex/tasks/task_e_6895e6bf4254832796b48f1a54d9749b