### PR TITLE
Handle missing Podman units and OVS containers

### DIFF
--- a/ansible/roles/openvswitch/tasks/post-deploy.yml
+++ b/ansible/roles/openvswitch/tasks/post-deploy.yml
@@ -1,5 +1,16 @@
 ---
 # NOTE(mnasiadka): external_ids:system-id uniquely identifies a physical system, used by OVN and other controllers
+- name: Check openvswitch db container presence
+  become: true
+  command: >-
+    {{ kolla_container_engine }}
+    {{ 'container exists openvswitch_db' if kolla_container_engine == 'podman' else 'container inspect openvswitch_db' }}
+  register: openvswitch_db_container
+  changed_when: false
+  failed_when: false
+  when:
+    - openvswitch_services['openvswitch-vswitchd'].enabled | bool
+
 - name: Wait for openvswitch db service to be ready
   become: true
   command: "{{ kolla_container_engine }} exec openvswitch_db ovs-vsctl --no-wait show"
@@ -9,7 +20,8 @@
   delay: 1
   changed_when: false
   when:
-    - openvswitch_services['openvswitch-vswitchd'].host_in_groups | bool
+    - openvswitch_services['openvswitch-vswitchd'].enabled | bool
+    - openvswitch_db_container.rc == 0
 
 - name: Set system-id, hostname and hw-offload
   become: true
@@ -31,7 +43,8 @@
   loop_control:
     loop_var: ovsdb_item
   when:
-    - openvswitch_services['openvswitch-vswitchd'].host_in_groups | bool
+    - openvswitch_services['openvswitch-vswitchd'].enabled | bool
+    - openvswitch_db_container.rc == 0
   notify:
     - "Restart openvswitch-vswitchd container"
 
@@ -46,6 +59,8 @@
       fail_mode: standalone
   loop: "{{ neutron_bridge_name.split(',') }}"
   when:
+    - openvswitch_services['openvswitch-vswitchd'].enabled | bool
+    - openvswitch_db_container.rc == 0
     - inventory_hostname in groups["network"]
       or (inventory_hostname in groups["compute"] and computes_need_external_bridge | bool )
 
@@ -62,5 +77,7 @@
     - "{{ neutron_bridge_name.split(',') }}"
     - "{{ neutron_external_interface.split(',') }}"
   when:
+    - openvswitch_services['openvswitch-vswitchd'].enabled | bool
+    - openvswitch_db_container.rc == 0
     - inventory_hostname in groups["network"]
       or (inventory_hostname in groups["compute"] and computes_need_external_bridge | bool )

--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -1,14 +1,31 @@
 ---
-- name: Detect services with systemd units
+- name: Gather systemd service units
   become: true
-  stat:
-    path: "{{ item.0 }}/{{ kolla_service_unit_prefix }}{{ item.1 }}{{ kolla_service_unit_suffix }}.service"
-  loop: "{{ kolla_service_unit_search_paths | product(kolla_service_start_priority) | list }}"
-  register: service_units
+  command: systemctl list-unit-files --type=service --no-legend
+  register: service_units_cmd
+  changed_when: false
 
-- name: Build list of services with systemd units
+- name: Initialize service unit map
   set_fact:
-    existing_unit_services: "{{ service_units.results | json_query('[?stat.exists].item[1]') | unique }}"
+    service_unit_map: {}
+
+- name: Build map of services with systemd units
+  set_fact:
+    service_unit_map: "{{ service_unit_map | default({}) | combine({ item: unit_name }) }}"
+  vars:
+    candidate_units: >-
+      {{
+        (kolla_container_engine == 'podman')
+        | ternary(['container-' + item + '.service', 'kolla-' + item + '-container.service'],
+                  ['kolla-' + item + '-container.service'])
+      }}
+    unit_name: >-
+      {{
+        (candidate_units | select('in', service_units_cmd.stdout_lines | map('split') | map('first') | list)
+         | list | first | default('')) | regex_replace('\\.service$','')
+      }}
+  loop: "{{ kolla_service_start_priority }}"
+  when: unit_name != ''
 
 - name: Gather running containers
   become: true
@@ -18,7 +35,7 @@
 
 - name: Determine services missing systemd units
   set_fact:
-    missing_unit_services: "{{ kolla_service_start_priority | difference(existing_unit_services) | intersect(start_order_containers.stdout_lines) }}"
+    missing_unit_services: "{{ kolla_service_start_priority | difference(service_unit_map.keys() | list) | intersect(start_order_containers.stdout_lines) }}"
 
 - name: Generate systemd units for containers lacking them
   include_tasks: generate_unit.yml
@@ -32,9 +49,17 @@
     - kolla_container_engine == 'podman'
     - missing_unit_services | length > 0
 
+- name: Update service unit map with generated units
+  set_fact:
+    service_unit_map: "{{ service_unit_map | combine({ item: 'container-' + item }) }}"
+  loop: "{{ missing_unit_services }}"
+  when:
+    - kolla_container_engine == 'podman'
+    - missing_unit_services | length > 0
+
 - name: Build start order services
   set_fact:
-    start_order_services: "{{ kolla_service_start_priority | select('in', existing_unit_services + missing_unit_services) | list }}"
+    start_order_services: "{{ kolla_service_start_priority | select('in', service_unit_map.keys() | list) | list }}"
 
 - name: Build start order pairs
   set_fact:
@@ -43,7 +68,7 @@
 - name: Ensure override directories exist
   become: true
   file:
-    path: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item.1 }}{{ kolla_service_unit_suffix }}.service.d"
+    path: "/etc/systemd/system/{{ service_unit_map[item.1] }}.service.d"
     state: directory
   loop: "{{ start_order_pairs }}"
   notify: Reload systemd
@@ -52,14 +77,14 @@
   become: true
   template:
     src: start-order.conf.j2
-    dest: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item.1 }}{{ kolla_service_unit_suffix }}.service.d/start-order.conf"
+    dest: "/etc/systemd/system/{{ service_unit_map[item.1] }}.service.d/start-order.conf"
     mode: "0644"
   loop: "{{ start_order_pairs }}"
   notify: Reload systemd
 
 - name: Detect systemd dependency cycles
   become: true
-  command: "systemd-analyze verify {{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+  command: "systemd-analyze verify {{ service_unit_map[item] }}.service"
   loop: "{{ start_order_services }}"
   loop_control:
     label: "{{ item }}"

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -8,23 +8,27 @@
 - name: Check if {{ item }} unit file exists
   become: true
   stat:
-    path: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+    path: "/etc/systemd/system/{{ service_unit_map[item] }}.service"
   register: service_unit_etc
+  when: item in service_unit_map
 
 - name: Check if {{ item }} unit file exists in /usr/lib
   become: true
   stat:
-    path: "/usr/lib/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+    path: "/usr/lib/systemd/system/{{ service_unit_map[item] }}.service"
   register: service_unit_usr
-  when: not service_unit_etc.stat.exists
+  when:
+    - item in service_unit_map
+    - not service_unit_etc.stat.exists
 
 - name: Start {{ item }} service
   become: true
   systemd:
-    name: "{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+    name: "{{ service_unit_map[item] }}.service"
     state: started
     enabled: true
   when:
+    - item in service_unit_map
     - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
     - service_unit_etc.stat.exists or service_unit_usr.stat.exists | default(false)
 
@@ -40,5 +44,6 @@
   until: cleanup_state.states.neutron_ovs_cleanup != 'running'
   when:
     - item == 'neutron_ovs_cleanup'
+    - item in service_unit_map
     - service_unit_etc.stat.exists or service_unit_usr.stat.exists | default(false)
     - not ovs_cleanup_marker.stat.exists | default(false)

--- a/ansible/roles/service-start-order/templates/start-order.conf.j2
+++ b/ansible/roles/service-start-order/templates/start-order.conf.j2
@@ -1,6 +1,6 @@
 [Unit]
-After={{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}.service
-Requires={{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}.service
+After={{ service_unit_map[item.0] }}.service
+Requires={{ service_unit_map[item.0] }}.service
 
 [Service]
 ExecStartPre=/bin/bash -c '\

--- a/doc/source/reference/podman.rst
+++ b/doc/source/reference/podman.rst
@@ -21,6 +21,13 @@ systemd unit are absent or disabled, ``service-check-containers`` skips any
 restart or enablement attempts. This allows staged deployments where only a
 subset of services are present without causing unnecessary failures.
 
+The ``service-start-order`` role recognises both native Podman unit names
+such as ``container-<name>.service`` and Kolla wrapper units like
+``kolla-<name>-container.service``. Services without either a running
+container or a systemd unit are ignored. This mirrors the behaviour of
+``service-check-containers`` and permits hosts to omit specific services
+without triggering errors during startup sequencing.
+
 When unit files are present, the ``service-start-order`` role waits for the
 previous container to report a ``healthy`` state via
 ``podman inspect --format '{{.State.Health.Status}}'`` before starting the next

--- a/molecule/openvswitch-no-container/molecule.yml
+++ b/molecule/openvswitch-no-container/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/openvswitch-no-container/playbook.yml
+++ b/molecule/openvswitch-no-container/playbook.yml
@@ -1,0 +1,31 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    kolla_container_engine: podman
+    enable_openvswitch: true
+    openvswitch_services:
+      openvswitch-db-server:
+        container_name: openvswitch_db
+        enabled: true
+        host_in_groups: true
+      openvswitch-vswitchd:
+        container_name: openvswitch_vswitchd
+        enabled: true
+        host_in_groups: true
+  tasks:
+    - name: Ensure openvswitch containers are absent
+      become: true
+      command: podman container rm -f {{ item }}
+      register: rm_res
+      changed_when: rm_res.rc == 0
+      failed_when: rm_res.rc not in [0,1,125]
+      loop:
+        - openvswitch_db
+        - openvswitch_vswitchd
+
+    - name: Run openvswitch post-deploy tasks
+      include_role:
+        name: openvswitch
+        tasks_from: post-deploy

--- a/molecule/openvswitch-no-container/verify.yml
+++ b/molecule/openvswitch-no-container/verify.yml
@@ -1,0 +1,16 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check db container missing
+      become: true
+      command: podman container exists openvswitch_db
+      register: db_exists
+      changed_when: false
+      failed_when: false
+
+    - name: Assert container missing
+      assert:
+        that:
+          - db_exists.rc != 0

--- a/molecule/service_start_order_no_container/molecule.yml
+++ b/molecule/service_start_order_no_container/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/service_start_order_no_container/playbook.yml
+++ b/molecule/service_start_order_no_container/playbook.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    kolla_action: deploy
+    kolla_container_engine: podman
+    kolla_service_start_priority:
+      - kolla_toolbox
+  tasks:
+    - name: Ensure kolla_toolbox container is absent
+      become: true
+      command: podman container rm -f kolla_toolbox
+      register: rm_toolbox
+      changed_when: rm_toolbox.rc == 0
+      failed_when: rm_toolbox.rc not in [0,1,125]
+
+    - name: Run service-start-order role
+      include_role:
+        name: service-start-order

--- a/molecule/service_start_order_no_container/verify.yml
+++ b/molecule/service_start_order_no_container/verify.yml
@@ -1,0 +1,31 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check container missing
+      become: true
+      command: podman container exists kolla_toolbox
+      register: toolbox_exists
+      changed_when: false
+      failed_when: false
+
+    - name: Check no systemd unit created (container prefix)
+      become: true
+      stat:
+        path: /etc/systemd/system/container-kolla_toolbox.service
+      register: container_unit
+
+    - name: Check no systemd unit created (kolla prefix)
+      become: true
+      stat:
+        path: /etc/systemd/system/kolla-kolla_toolbox-container.service
+      register: kolla_unit
+
+    - name: Assert service skipped
+      assert:
+        that:
+          - toolbox_exists.rc != 0
+          - not container_unit.stat.exists
+          - not kolla_unit.stat.exists
+          - hostvars['localhost']['start_order_services'] == []

--- a/releasenotes/notes/podman-start-order-ovs-skip.yaml
+++ b/releasenotes/notes/podman-start-order-ovs-skip.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    The ``service-start-order`` role now detects both native Podman
+    ``container-<name>.service`` units and Kolla wrapper units named
+    ``kolla-<name>-container.service``. Services without a corresponding
+    unit or running container are skipped, allowing staged deployments
+    where some services are absent.
+  - |
+    The ``openvswitch`` role's post-deploy tasks now verify that the
+    ``openvswitch_db`` container exists and that the service is enabled
+    before attempting any configuration. This prevents failures on hosts
+    where Open vSwitch is not deployed.


### PR DESCRIPTION
## Summary
- detect both `container-` and `kolla-` systemd units when ordering service starts
- skip Open vSwitch post-deploy actions when the database container or service is absent
- document Podman unit naming and add Molecule scenarios for missing services

## Testing
- `tox -e linters` (fails: 23 failures)
- `molecule test -s service_start_order_no_container` (fails: Failed to find driver delegated)
- `molecule test -s openvswitch-no-container` (fails: Failed to find driver delegated)


------
https://chatgpt.com/codex/tasks/task_e_6895ed62c4188327b2863961ee89adb7