### PR TITLE
Verify Open vSwitch service availability in service-start-order

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -9,6 +9,12 @@
   set_fact:
     service_unit_map: {}
 
+- name: Remove Open vSwitch services when disabled
+  set_fact:
+    kolla_service_start_priority: "{{ kolla_service_start_priority | difference(['openvswitch_db', 'openvswitch_vswitchd', 'neutron_ovs_cleanup', 'neutron_openvswitch_agent']) }}"
+  when:
+    - not enable_openvswitch | bool
+
 - name: Build map of services with systemd units
   set_fact:
     service_unit_map: "{{ service_unit_map | default({}) | combine({ item: unit_name }) }}"
@@ -27,9 +33,19 @@
   loop: "{{ kolla_service_start_priority }}"
   when: unit_name != ''
 
+- name: Ensure Open vSwitch units are present when enabled
+  assert:
+    that:
+      - "'openvswitch_db' in service_unit_map"
+      - "'openvswitch_vswitchd' in service_unit_map"
+    fail_msg: >-
+      Open vSwitch services are missing. Ensure the openvswitch role has
+      deployed the required containers when enable_openvswitch is true.
+  when: enable_openvswitch | bool
+
 - name: Gather running containers
   become: true
-  command: "{{ kolla_container_engine }} ps --format '{{ '{{.Names}}' }}'"
+  command: "{{ kolla_container_engine }} ps -a --format '{{ '{{.Names}}' }}'"
   register: start_order_containers
   changed_when: false
 

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -33,6 +33,13 @@ Unit files may be supplied either in ``/usr/lib/systemd/system`` or
 installs it under ``/etc/systemd/system`` before applying the start-order
 overrides.
 
+When ``enable_openvswitch`` is ``true`` the role requires the
+``openvswitch_db`` and ``openvswitch_vswitchd`` unit files to be present.
+If either is missing, the role fails early rather than starting dependent
+containers such as ``neutron_openvswitch_agent`` and ``nova_libvirt``.
+Setting ``enable_openvswitch`` to ``false`` removes these services from the
+startup sequence.
+
 One-shot cleanup containers
 ---------------------------
 

--- a/molecule/service_start_order_openvswitch/molecule.yml
+++ b/molecule/service_start_order_openvswitch/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/service_start_order_openvswitch/playbook.yml
+++ b/molecule/service_start_order_openvswitch/playbook.yml
@@ -1,0 +1,68 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:  # noqa var-naming[read-only]
+      compute:
+        - localhost
+    enable_openvswitch: true
+    kolla_container_engine: podman
+    docker_common_options: {}
+  tasks:
+    - name: Start Podman REST API service
+      become: true
+      shell: podman system service --time=0 &
+      changed_when: false
+
+    - name: Wait for Podman REST socket
+      become: true
+      wait_for:
+        path: /run/podman/podman.sock
+        timeout: 5
+
+    - name: Ensure test containers are present
+      become: true
+      loop:
+        - openvswitch_db
+        - openvswitch_vswitchd
+        - neutron_openvswitch_agent
+        - nova_libvirt
+      command: >-
+        podman run -d --name {{ item }} docker.io/library/busybox:latest tail -f /dev/null
+      register: container_run
+      changed_when: container_run.rc == 0
+      failed_when: container_run.rc not in [0,125]
+
+    - name: Create systemd units
+      become: true
+      loop:
+        - openvswitch_db
+        - openvswitch_vswitchd
+        - neutron_openvswitch_agent
+        - nova_libvirt
+      copy:
+        dest: /usr/lib/systemd/system/container-{{ item }}.service
+        content: |
+          [Unit]
+          Description={{ item }}
+          [Service]
+          ExecStart=/usr/bin/podman start -a {{ item }}
+          ExecStop=/usr/bin/podman stop -t 10 {{ item }}
+          Restart=always
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Reload systemd
+      become: true
+      command: systemctl daemon-reload
+      changed_when: false
+
+    - name: Run service-start-order role
+      include_role:
+        name: service-start-order
+
+    - name: Assert services detected
+      assert:
+        that:
+          - start_order_services == ['openvswitch_db', 'openvswitch_vswitchd', 'neutron_openvswitch_agent', 'nova_libvirt']

--- a/molecule/service_start_order_openvswitch/verify.yml
+++ b/molecule/service_start_order_openvswitch/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Read drop-in for neutron_openvswitch_agent
+      become: true
+      slurp:
+        path: /etc/systemd/system/container-neutron_openvswitch_agent.service.d/start-order.conf
+      register: dropin
+
+    - name: Assert drop-in references openvswitch_vswitchd
+      vars:
+        content: "{{ dropin.content | b64decode }}"
+      assert:
+        that:
+          - "'After=container-openvswitch_vswitchd.service' in content"
+          - "'Requires=container-openvswitch_vswitchd.service' in content"

--- a/molecule/service_start_order_openvswitch_disabled/molecule.yml
+++ b/molecule/service_start_order_openvswitch_disabled/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/service_start_order_openvswitch_disabled/playbook.yml
+++ b/molecule/service_start_order_openvswitch_disabled/playbook.yml
@@ -1,0 +1,58 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:  # noqa var-naming[read-only]
+      compute:
+        - localhost
+    enable_openvswitch: false
+    kolla_container_engine: podman
+    docker_common_options: {}
+  tasks:
+    - name: Start Podman REST API service
+      become: true
+      shell: podman system service --time=0 &
+      changed_when: false
+
+    - name: Wait for Podman REST socket
+      become: true
+      wait_for:
+        path: /run/podman/podman.sock
+        timeout: 5
+
+    - name: Ensure nova_libvirt container is present
+      become: true
+      command: >-
+        podman run -d --name nova_libvirt docker.io/library/busybox:latest tail -f /dev/null
+      register: container_run
+      changed_when: container_run.rc == 0
+      failed_when: container_run.rc not in [0,125]
+
+    - name: Create systemd unit for nova_libvirt
+      become: true
+      copy:
+        dest: /usr/lib/systemd/system/container-nova_libvirt.service
+        content: |
+          [Unit]
+          Description=nova_libvirt
+          [Service]
+          ExecStart=/usr/bin/podman start -a nova_libvirt
+          ExecStop=/usr/bin/podman stop -t 10 nova_libvirt
+          Restart=always
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Reload systemd
+      become: true
+      command: systemctl daemon-reload
+      changed_when: false
+
+    - name: Run service-start-order role
+      include_role:
+        name: service-start-order
+
+    - name: Assert openvswitch services skipped
+      assert:
+        that:
+          - start_order_services == ['nova_libvirt']

--- a/molecule/service_start_order_openvswitch_disabled/verify.yml
+++ b/molecule/service_start_order_openvswitch_disabled/verify.yml
@@ -1,0 +1,15 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check openvswitch drop-in absent
+      become: true
+      stat:
+        path: /etc/systemd/system/container-openvswitch_db.service.d/start-order.conf
+      register: ovs_dropin
+
+    - name: Assert drop-in absent
+      assert:
+        that:
+          - not ovs_dropin.stat.exists

--- a/releasenotes/notes/ovs-start-order-check-8f3b6e2d9383.yaml
+++ b/releasenotes/notes/ovs-start-order-check-8f3b6e2d9383.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The ``service-start-order`` role now verifies that Open vSwitch services
+    are present when ``enable_openvswitch`` is ``true``. Missing
+    ``openvswitch_db`` or ``openvswitch_vswitchd`` units cause the role to
+    fail early instead of starting dependent containers such as
+    ``neutron_openvswitch_agent`` and ``nova_libvirt``. When
+    ``enable_openvswitch`` is ``false`` these services are skipped entirely.


### PR DESCRIPTION
## Summary
- ensure service-start-order asserts Open vSwitch services when enabled
- document enable_openvswitch expectations for Podman deployments
- add molecule scenarios covering Open vSwitch enabled and disabled cases

## Testing
- `tox -e linters` *(fails: Listing 23 violation(s) that are fatal)*
- `molecule test -s service_start_order_openvswitch` *(fails: driver delegated not found)*
- `molecule test -s service_start_order_openvswitch_disabled` *(fails: driver delegated not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f442bfac8327bbd8abf74aaa43f2