### PR TITLE
Fail early when Open vSwitch containers are missing

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -49,6 +49,16 @@
   register: start_order_containers
   changed_when: false
 
+- name: Ensure Open vSwitch containers are present when enabled
+  assert:
+    that:
+      - "'openvswitch_db' in start_order_containers.stdout_lines"
+      - "'openvswitch_vswitchd' in start_order_containers.stdout_lines"
+    fail_msg: >-
+      Open vSwitch containers are missing. Ensure the openvswitch role has
+      deployed the required containers when enable_openvswitch is true.
+  when: enable_openvswitch | bool
+
 - name: Determine services missing systemd units
   set_fact:
     missing_unit_services: "{{ kolla_service_start_priority | difference(service_unit_map.keys() | list) | intersect(start_order_containers.stdout_lines) }}"

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -33,12 +33,12 @@ Unit files may be supplied either in ``/usr/lib/systemd/system`` or
 installs it under ``/etc/systemd/system`` before applying the start-order
 overrides.
 
-When ``enable_openvswitch`` is ``true`` the role requires the
-``openvswitch_db`` and ``openvswitch_vswitchd`` unit files to be present.
-If either is missing, the role fails early rather than starting dependent
-containers such as ``neutron_openvswitch_agent`` and ``nova_libvirt``.
-Setting ``enable_openvswitch`` to ``false`` removes these services from the
-startup sequence.
+When ``enable_openvswitch`` is ``true`` the role requires both the
+``openvswitch_db`` and ``openvswitch_vswitchd`` containers and their unit
+files to be present. If any are missing, the role fails early rather than
+starting dependent containers such as ``neutron_openvswitch_agent`` and
+``nova_libvirt``. Setting ``enable_openvswitch`` to ``false`` removes these
+services from the startup sequence.
 
 One-shot cleanup containers
 ---------------------------

--- a/molecule/service_start_order_openvswitch_no_container/molecule.yml
+++ b/molecule/service_start_order_openvswitch_no_container/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify
+

--- a/molecule/service_start_order_openvswitch_no_container/playbook.yml
+++ b/molecule/service_start_order_openvswitch_no_container/playbook.yml
@@ -1,0 +1,56 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:  # noqa var-naming[read-only]
+      compute:
+        - localhost
+    enable_openvswitch: true
+    kolla_container_engine: podman
+    docker_common_options: {}
+  tasks:
+    - name: Start Podman REST API service
+      become: true
+      shell: podman system service --time=0 &
+      changed_when: false
+
+    - name: Wait for Podman REST socket
+      become: true
+      wait_for:
+        path: /run/podman/podman.sock
+        timeout: 5
+
+    - name: Create systemd units for missing OVS containers
+      become: true
+      loop:
+        - openvswitch_db
+        - openvswitch_vswitchd
+      copy:
+        dest: /usr/lib/systemd/system/container-{{ item }}.service
+        content: |
+          [Unit]
+          Description={{ item }}
+          [Service]
+          ExecStart=/usr/bin/podman start -a {{ item }}
+          ExecStop=/usr/bin/podman stop -t 10 {{ item }}
+          Restart=always
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Reload systemd
+      become: true
+      command: systemctl daemon-reload
+      changed_when: false
+
+    - name: Run service-start-order role (expect failure)
+      include_role:
+        name: service-start-order
+      register: start_order_result
+      ignore_errors: true
+
+    - name: Assert role failed due to missing containers
+      assert:
+        that:
+          - start_order_result is failed
+

--- a/molecule/service_start_order_openvswitch_no_container/verify.yml
+++ b/molecule/service_start_order_openvswitch_no_container/verify.yml
@@ -1,0 +1,6 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks: []
+

--- a/releasenotes/notes/ovs-start-order-check-8f3b6e2d9383.yaml
+++ b/releasenotes/notes/ovs-start-order-check-8f3b6e2d9383.yaml
@@ -3,7 +3,7 @@ fixes:
   - |
     The ``service-start-order`` role now verifies that Open vSwitch services
     are present when ``enable_openvswitch`` is ``true``. Missing
-    ``openvswitch_db`` or ``openvswitch_vswitchd`` units cause the role to
-    fail early instead of starting dependent containers such as
-    ``neutron_openvswitch_agent`` and ``nova_libvirt``. When
+    ``openvswitch_db`` or ``openvswitch_vswitchd`` containers or unit files
+    cause the role to fail early instead of starting dependent containers such
+    as ``neutron_openvswitch_agent`` and ``nova_libvirt``. When
     ``enable_openvswitch`` is ``false`` these services are skipped entirely.


### PR DESCRIPTION
## Summary
- ensure service-start-order role verifies openvswitch_db and openvswitch_vswitchd containers exist when enabled
- document requirement for OVS containers and unit files
- add molecule test for missing Open vSwitch containers

## Testing
- `python3 -m tox -e linters` *(fails: exit -15)*
- `python3 -m molecule test -s service_start_order_openvswitch_no_container` *(fails: driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895fb4062f883278a3d267a87eccfcd