### PR TITLE
Check containers before systemd units

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -1,4 +1,16 @@
 ---
+- name: Gather running containers
+  become: true
+  command: "{{ kolla_container_engine }} ps -a --format '{{ '{{.Names}}' }}'"
+  register: start_order_containers
+  changed_when: false
+
+- name: Remove Open vSwitch services when disabled
+  set_fact:
+    kolla_service_start_priority: "{{ kolla_service_start_priority | difference(['openvswitch_db', 'openvswitch_vswitchd', 'neutron_ovs_cleanup', 'neutron_openvswitch_agent']) }}"
+  when:
+    - not enable_openvswitch | bool
+
 - name: Gather systemd service units
   become: true
   command: systemctl list-unit-files --type=service --no-legend
@@ -8,12 +20,6 @@
 - name: Initialize service unit map
   set_fact:
     service_unit_map: {}
-
-- name: Remove Open vSwitch services when disabled
-  set_fact:
-    kolla_service_start_priority: "{{ kolla_service_start_priority | difference(['openvswitch_db', 'openvswitch_vswitchd', 'neutron_ovs_cleanup', 'neutron_openvswitch_agent']) }}"
-  when:
-    - not enable_openvswitch | bool
 
 - name: Build map of services with systemd units
   set_fact:
@@ -31,23 +37,9 @@
          | list | first | default('')) | regex_replace('\\.service$','')
       }}
   loop: "{{ kolla_service_start_priority }}"
-  when: unit_name != ''
-
-- name: Ensure Open vSwitch units are present when enabled
-  assert:
-    that:
-      - "'openvswitch_db' in service_unit_map"
-      - "'openvswitch_vswitchd' in service_unit_map"
-    fail_msg: >-
-      Open vSwitch services are missing. Ensure the openvswitch role has
-      deployed the required containers when enable_openvswitch is true.
-  when: enable_openvswitch | bool
-
-- name: Gather running containers
-  become: true
-  command: "{{ kolla_container_engine }} ps -a --format '{{ '{{.Names}}' }}'"
-  register: start_order_containers
-  changed_when: false
+  when:
+    - item in start_order_containers.stdout_lines
+    - unit_name != ''
 
 - name: Ensure Open vSwitch containers are present when enabled
   assert:
@@ -56,6 +48,16 @@
       - "'openvswitch_vswitchd' in start_order_containers.stdout_lines"
     fail_msg: >-
       Open vSwitch containers are missing. Ensure the openvswitch role has
+      deployed the required containers when enable_openvswitch is true.
+  when: enable_openvswitch | bool
+
+- name: Ensure Open vSwitch units are present when enabled
+  assert:
+    that:
+      - "'openvswitch_db' in service_unit_map"
+      - "'openvswitch_vswitchd' in service_unit_map"
+    fail_msg: >-
+      Open vSwitch services are missing. Ensure the openvswitch role has
       deployed the required containers when enable_openvswitch is true.
   when: enable_openvswitch | bool
 

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -5,6 +5,15 @@
   register: ovs_cleanup_marker
   when: item == 'neutron_ovs_cleanup'
 
+- name: Ensure Open vSwitch is ready for {{ item }}
+  assert:
+    that:
+      - ovs_ready | default(false)
+    fail_msg: "Open vSwitch is not ready; cannot start {{ item }}"
+  when:
+    - enable_openvswitch | bool
+    - item in ['neutron_ovs_cleanup', 'neutron_openvswitch_agent', 'nova_libvirt']
+
 - name: Check if {{ item }} unit file exists
   become: true
   stat:
@@ -31,6 +40,37 @@
     - item in service_unit_map
     - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
     - service_unit_etc.stat.exists or service_unit_usr.stat.exists | default(false)
+
+- name: Check Open vSwitch readiness
+  when:
+    - item == 'openvswitch_vswitchd'
+    - enable_openvswitch | bool
+  block:
+    - name: Get Open vSwitch container states
+      become: true
+      kolla_container_facts:
+        action: get_containers_state
+        container_engine: "{{ kolla_container_engine }}"
+        name:
+          - openvswitch_db
+          - openvswitch_vswitchd
+      register: ovs_states
+
+    - name: Run ovs-vsctl show
+      become: true
+      command: "{{ kolla_container_engine }} exec openvswitch_db ovs-vsctl --no-wait show"
+      register: ovs_vsctl
+      changed_when: false
+
+    - name: Set ovs_ready flag
+      set_fact:
+        ovs_ready: "{{ ovs_states.states.openvswitch_db == 'running' and ovs_states.states.openvswitch_vswitchd == 'running' and ovs_vsctl.rc == 0 }}"
+
+    - name: Ensure Open vSwitch is ready
+      assert:
+        that:
+          - ovs_ready | bool
+        fail_msg: "Open vSwitch containers failed to start"
 
 - name: Wait for neutron_ovs_cleanup to finish
   become: true

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -28,16 +28,19 @@ messaging back ends are available before the corresponding API services are
 launched.
 
 Unit files may be supplied either in ``/usr/lib/systemd/system`` or
-``/etc/systemd/system``. If a running container lacks a unit file,
-``service-start-order`` generates one using ``podman generate systemd`` and
-installs it under ``/etc/systemd/system`` before applying the start-order
-overrides.
+``/etc/systemd/system``.  The ``service-start-order`` role detects services
+based on the presence of a container.  Orphaned systemd unit files without a
+matching container are ignored so stale units do not affect startup.  If a
+running container lacks a unit file, ``service-start-order`` generates one
+using ``podman generate systemd`` and installs it under
+``/etc/systemd/system`` before applying the start-order overrides.
 
-When ``enable_openvswitch`` is ``true`` the role requires both the
-``openvswitch_db`` and ``openvswitch_vswitchd`` containers and their unit
-files to be present. If any are missing, the role fails early rather than
-starting dependent containers such as ``neutron_openvswitch_agent`` and
-``nova_libvirt``. Setting ``enable_openvswitch`` to ``false`` removes these
+When ``enable_openvswitch`` is ``true`` the role verifies that the
+``openvswitch_db`` and ``openvswitch_vswitchd`` containers exist, their unit
+files are present, and ``ovs-vsctl --no-wait show`` succeeds before starting
+dependent containers such as ``neutron_openvswitch_agent`` and
+``nova_libvirt``.  Stale unit files without containers are ignored and do not
+satisfy this check.  Setting ``enable_openvswitch`` to ``false`` removes these
 services from the startup sequence.
 
 One-shot cleanup containers

--- a/molecule/service_start_order_openvswitch/playbook.yml
+++ b/molecule/service_start_order_openvswitch/playbook.yml
@@ -34,6 +34,11 @@
       changed_when: container_run.rc == 0
       failed_when: container_run.rc not in [0,125]
 
+    - name: Stub ovs-vsctl in openvswitch_db container
+      become: true
+      command: podman exec openvswitch_db ln -s /bin/true /usr/bin/ovs-vsctl
+      changed_when: false
+
     - name: Create systemd units
       become: true
       loop:

--- a/releasenotes/notes/ovs-container-first-detection-a1b2c3.yaml
+++ b/releasenotes/notes/ovs-container-first-detection-a1b2c3.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    The ``service-start-order`` role now detects services based on existing
+    containers rather than systemd unit files, ignoring orphaned unit files.
+    When ``enable_openvswitch`` is ``true`` the role verifies that the
+    ``openvswitch_db`` and ``openvswitch_vswitchd`` containers are running and
+    ``ovs-vsctl --no-wait show`` succeeds before starting dependent services.
+    Stale Open vSwitch units without containers no longer allow downstream
+    services to start.


### PR DESCRIPTION
## Summary
- ignore orphaned Podman unit files by mapping services only when containers exist
- verify Open vSwitch containers and readiness before starting dependent services
- document container-first detection and OVS readiness checks for Podman deployments

## Testing
- `tox -e linters` *(fails: 26 violations)*
- `molecule test -s service_start_order_openvswitch` *(fails: Operation not permitted running podman)*
- `molecule test -s service_start_order_openvswitch_no_container` *(fails: System has not been booted with systemd)*

------
https://chatgpt.com/codex/tasks/task_e_6895ff2418588327b7b404490017af6b