### PR TITLE
Fix Podman systemd unit naming and cleanup script

### DIFF
--- a/ansible/module_utils/kolla_systemd_worker.py
+++ b/ansible/module_utils/kolla_systemd_worker.py
@@ -30,7 +30,7 @@ StartLimitBurst=${restart_retries}
 
 [Service]
 ExecStart=/usr/bin/${engine} start -a ${name}
-ExecStop=/usr/bin/${engine} stop ${name} -t ${graceful_timeout}
+ExecStop=/usr/bin/${engine} stop -t ${graceful_timeout} ${name}
 Restart=${restart_policy}
 RestartSec=${restart_duration}
 SuccessExitStatus=143
@@ -51,8 +51,12 @@ class SystemdWorker(object):
         container_engine = params.get('container_engine')
         if container_engine == 'docker':
             dependencies = 'docker.service'
+            unit_prefix = 'kolla-'
+            unit_suffix = '-container'
         else:
             dependencies = 'network-online.target'
+            unit_prefix = 'container-'
+            unit_suffix = ''
 
         restart_policy = params.get('restart_policy', 'no')
         if restart_policy == 'unless-stopped':
@@ -69,7 +73,7 @@ class SystemdWorker(object):
         # container info
         self.container_dict = dict(
             name=name,
-            service_name='kolla-' + name + '-container.service',
+            service_name=f"{unit_prefix}{name}{unit_suffix}.service",
             engine=container_engine,
             deps=dependencies,
             graceful_timeout=params.get('graceful_timeout'),

--- a/doc/source/reference/podman.rst
+++ b/doc/source/reference/podman.rst
@@ -2,9 +2,13 @@
 Podman Container Management
 ============================
 
+When using Podman, systemd unit files are generated as
+``container-<name>.service`` for each managed container. This differs from
+Docker where unit files are named ``kolla-<name>-container.service``.
+
 Some Kolla Ansible containers may be started outside of systemd and therefore
-lack a corresponding ``container-<name>.service`` unit. A common example is
-``kolla_toolbox``, which is launched during bootstrap and left running.
+lack a corresponding unit. A common example is ``kolla_toolbox``, which is
+launched during bootstrap and left running.
 
 The ``service-check-containers`` and ``service-start-order`` roles verify and
 start containers via their systemd units. When using Podman, these roles check

--- a/doc/source/user/operating-kolla.rst
+++ b/doc/source/user/operating-kolla.rst
@@ -289,11 +289,12 @@ Kolla ships with several utilities intended to facilitate ease of operation.
 ``tools/cleanup-containers`` is used to remove deployed containers from the
 system. This can be useful when you want to do a new clean deployment. It will
 preserve the registry and the locally built images in the registry, but will
-remove all running Kolla containers from the local Docker daemon. It also
-removes the named volumes.
+remove all running Kolla containers from the selected container engine. It also
+removes the corresponding systemd units (``kolla-<name>-container.service`` for
+Docker and ``container-<name>.service`` for Podman) and the named volumes.
 
 ``tools/cleanup-host`` is used to remove remnants of network changes
-triggered on the Docker host when the neutron-agents containers are launched.
+triggered on the host when the neutron-agents containers are launched.
 This can be useful when you want to do a new clean deployment, particularly one
 changing the network topology.
 

--- a/tools/cleanup-containers
+++ b/tools/cleanup-containers
@@ -11,6 +11,14 @@ fi
 
 echo "Using container engine: $engine"
 
+if [ "$engine" = "podman" ]; then
+    unit_prefix="container-"
+    unit_suffix=""
+else
+    unit_prefix="kolla-"
+    unit_suffix="-container"
+fi
+
 containers_running=$(sudo $engine ps --filter "label=kolla_version" --format "{{.Names}}")
 
 QEMU_PIDS=$(pgrep -l qemu | awk '!/qemu-ga/  && !/qemu-img/ {print $1}')
@@ -42,10 +50,10 @@ fi
 
 echo "Stopping containers..."
 for container in ${containers_to_kill}; do
-sudo systemctl disable kolla-${container}-container.service
-sudo systemctl stop kolla-${container}-container.service
-sudo systemctl is-failed kolla-${container}-container.service && \
-sudo systemctl reset-failed kolla-${container}-container.service
+sudo systemctl disable ${unit_prefix}${container}${unit_suffix}.service
+sudo systemctl stop ${unit_prefix}${container}${unit_suffix}.service
+sudo systemctl is-failed ${unit_prefix}${container}${unit_suffix}.service && \
+sudo systemctl reset-failed ${unit_prefix}${container}${unit_suffix}.service
 done
 
 echo "Removing containers..."
@@ -63,7 +71,7 @@ echo "Removing link of kolla_log volume..."
 (sudo rm -f /var/log/kolla 2>&1) > /dev/null
 
 echo "Removing unit files..."
-sudo rm -f /etc/systemd/system/kolla-*-container.service
+sudo rm -f /etc/systemd/system/${unit_prefix}*${unit_suffix}.service
 sudo systemctl daemon-reload
 
 echo "All cleaned up!"


### PR DESCRIPTION
## Summary
- generate `container-*` systemd units for Podman containers
- update cleanup script to support Podman unit names
- document Podman service unit naming differences

## Testing
- `tox -e linters` *(fails: 19 failure(s))*

------
https://chatgpt.com/codex/tasks/task_e_68961906dd9c8327919e33495ca70b0e