### PR TITLE
podman: make systemd optional

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -98,6 +98,7 @@ database_enable_tls_internal: "{{ 'yes' if ((kolla_enable_tls_internal | bool ) 
 # Container engine options
 ####################
 kolla_container_engine: "docker"
+kolla_podman_use_systemd: false
 
 ####################
 # Docker options

--- a/ansible/roles/common/tasks/podman_systemd.yml
+++ b/ansible/roles/common/tasks/podman_systemd.yml
@@ -1,0 +1,37 @@
+---
+# Generate systemd unit for a Podman container
+- name: Generate systemd unit for {{ service.container_name }}
+  become: true
+  command: >-
+    podman generate systemd --name --files --restart-policy=always --output /etc/systemd/system {{ service.container_name }}
+  args:
+    creates: "/etc/systemd/system/container-{{ service.container_name }}.service"
+  when:
+    - kolla_container_engine == 'podman'
+    - kolla_podman_use_systemd | bool
+    - service.enabled | bool
+
+# Add optional dependency lines
+- name: Configure systemd dependencies for {{ service.container_name }}
+  become: true
+  lineinfile:
+    path: "/etc/systemd/system/container-{{ service.container_name }}.service"
+    line: "{{ item }}"
+    insertafter: '^\[Unit\]$'
+  loop: "{{ service.podman_systemd_dependencies | default([]) }}"
+  when:
+    - kolla_container_engine == 'podman'
+    - kolla_podman_use_systemd | bool
+    - service.enabled | bool
+    - service.podman_systemd_dependencies is defined
+
+- name: Reload systemd and enable unit {{ service.container_name }}
+  become: true
+  systemd:
+    name: "container-{{ service.container_name }}.service"
+    enabled: true
+    daemon_reload: true
+  when:
+    - kolla_container_engine == 'podman'
+    - kolla_podman_use_systemd | bool
+    - service.enabled | bool

--- a/ansible/roles/openvswitch/defaults/main.yml
+++ b/ansible/roles/openvswitch/defaults/main.yml
@@ -33,6 +33,9 @@ openvswitch_services:
     volumes: "{{ openvswitch_vswitchd_default_volumes + openvswitch_vswitchd_extra_volumes }}"
     dimensions: "{{ openvswitch_vswitchd_dimensions }}"
     healthcheck: "{{ openvswitch_vswitchd_healthcheck }}"
+    podman_systemd_dependencies:
+      - "After=container-openvswitch_db.service"
+      - "Requires=container-openvswitch_db.service"
 
 ####################
 # Docker

--- a/ansible/roles/openvswitch/tasks/deploy.yml
+++ b/ansible/roles/openvswitch/tasks/deploy.yml
@@ -8,4 +8,9 @@
 - name: Flush Handlers
   meta: flush_handlers
 
+- import_tasks: podman-systemd.yml
+  when:
+    - kolla_container_engine == 'podman'
+    - kolla_podman_use_systemd | bool
+
 - import_tasks: post-config.yml

--- a/ansible/roles/openvswitch/tasks/podman-systemd.yml
+++ b/ansible/roles/openvswitch/tasks/podman-systemd.yml
@@ -1,0 +1,10 @@
+---
+- name: Generate Podman systemd units for Open vSwitch
+  include_role:
+    name: common
+    tasks_from: podman_systemd
+  vars:
+    service: "{{ item.value }}"
+  loop: "{{ openvswitch_services | select_services_enabled_and_mapped_to_host | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"

--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -11,7 +11,10 @@
   systemd:
     name: "{{ unit_name }}"
     state: restarted
-  when: unit_enabled
+  when:
+    - unit_enabled
+    - service.unit_file_exists | default(false) | bool
+    - kolla_container_engine == 'docker' or kolla_podman_use_systemd | bool
 
 - name: Recreate container when missing or drifted
   listen: Restart container
@@ -38,6 +41,8 @@
   when:
     - not container_needs_recreate | bool
     - runtime_restart.rc != 0
+    - service.unit_file_exists | default(false) | bool
+    - kolla_container_engine == 'docker' or kolla_podman_use_systemd | bool
 
 - name: Restart unit as fallback
   listen: Restart container
@@ -48,4 +53,6 @@
   when:
     - not container_needs_recreate | bool
     - runtime_restart.rc != 0
+    - service.unit_file_exists | default(false) | bool
+    - kolla_container_engine == 'docker' or kolla_podman_use_systemd | bool
 

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -87,7 +87,7 @@
 
 - name: Init service fact for handlers
   set_fact:
-    service: "{{ container_spec }}"
+    service: "{{ container_spec | combine({'unit_file_exists': unit_file.stat.exists}) }}"
 
 - name: Clear host error state
   meta: clear_host_errors
@@ -118,4 +118,5 @@
   when:
     - not container_missing
     - unit_file.stat.exists
+    - kolla_container_engine == 'docker' or kolla_podman_use_systemd | bool
     - (unit_active.rc | default(0)) != 0

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -12,6 +12,15 @@ When using ``*_extra_volumes`` options, Kolla Ansible will automatically
 create any missing host directories referenced by bind mounts with
 permissions ``0755`` before starting containers.
 
+Optional systemd management
+---------------------------
+
+By default Podman containers are managed directly by Kolla Ansible.
+Set ``kolla_podman_use_systemd: true`` in ``/etc/kolla/globals.yml`` to
+generate and enable systemd unit files for services. Unit files are
+installed as ``/etc/systemd/system/container-<name>.service`` and allow
+systemd to start containers during host boot.
+
 Sequential container start
 --------------------------
 

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -90,6 +90,8 @@ workaround_ansible_issue_8743: yes
 # Set desired container engine to deploy on or migrate to
 # Valid options are [ docker, podman ]
 #kolla_container_engine: docker
+# Use systemd to manage Podman containers
+#kolla_podman_use_systemd: "no"
 
 
 ################


### PR DESCRIPTION
## Summary
- avoid systemd operations on Podman unless kolla_podman_use_systemd is enabled
- generate Podman systemd units and dependencies for Open vSwitch when opted in
- document kolla_podman_use_systemd toggle

## Testing
- `tox -e linters` *(fails: KeyboardInterrupt - teardown started)*

------
https://chatgpt.com/codex/tasks/task_e_6899e15437988327a7edae9ae3c1c150