### PR TITLE
openvswitch: fix regression from PR #230

### DIFF
--- a/ansible/roles/openvswitch/tasks/deploy.yml
+++ b/ansible/roles/openvswitch/tasks/deploy.yml
@@ -13,4 +13,9 @@
     - kolla_container_engine == 'podman'
     - kolla_podman_use_systemd | bool
 
+- import_tasks: check-containers.yml
+  when:
+    - kolla_container_engine == 'podman'
+    - kolla_podman_use_systemd | bool
+
 - import_tasks: post-config.yml

--- a/ansible/roles/openvswitch/tasks/post-config.yml
+++ b/ansible/roles/openvswitch/tasks/post-config.yml
@@ -1,5 +1,16 @@
 ---
 # NOTE(mnasiadka): external_ids:system-id uniquely identifies a physical system, used by OVN and other controllers
+- name: Wait for Open vSwitch database socket
+  become: true
+  command: "{{ kolla_container_engine }} exec openvswitch_db ovsdb-client list-dbs"
+  register: ovsdb_wait
+  retries: 10
+  delay: 3
+  changed_when: false
+  until: ovsdb_wait.rc == 0
+  when:
+    - openvswitch_services['openvswitch-vswitchd'].host_in_groups | bool
+
 - name: Set system-id, hostname and hw-offload
   become: true
   kolla_toolbox:

--- a/doc/source/reference/networking/neutron.rst
+++ b/doc/source/reference/networking/neutron.rst
@@ -170,6 +170,16 @@ mechanism, you can change that using the ``neutron_plugin_agent`` variable in
 
    neutron_plugin_agent: "openvswitch"
 
+On hosts in the ``openvswitch`` group the role creates and starts the
+``openvswitch-db-server`` and ``openvswitch-vswitchd`` containers.  When
+using Podman their systemd units (``container-openvswitch_db.service`` and
+``container-openvswitch_vswitchd.service``) are generated and enabled.  The
+deployment waits for the Open vSwitch database socket to appear before
+applying any ``ovs-vsctl`` configuration, so running with
+``--limit`` still configures the host correctly.  If ``ovs-vsctl`` reports
+``Connection refused``, verify that the containers are running and that
+``/run/openvswitch/db.sock`` exists.
+
 When using Open vSwitch on a compatible kernel (4.3+ upstream, consult the
 documentation of your distribution for support details), you can switch
 to using the native OVS firewall driver by employing a configuration override


### PR DESCRIPTION
## Summary
- rerun container checks after generating Podman units so limited deployments create and start Open vSwitch containers
- wait for ovsdb socket before running ovs-vsctl configuration
- document podman unit generation and ovsdb wait with troubleshooting tip

## Testing
- `tox -e linters` *(fails: Duplicate keys, yaml formatting, jinja invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6899ec5ae1988327ad86b9eb47f0a54a