### PR TITLE
openvswitch: ensure units created before verification

### DIFF
--- a/ansible/roles/openvswitch/tasks/deploy.yml
+++ b/ansible/roles/openvswitch/tasks/deploy.yml
@@ -3,19 +3,14 @@
 
 - import_tasks: config.yml
 
-- import_tasks: check-containers.yml
-
-- name: Flush Handlers
-  meta: flush_handlers
-
 - import_tasks: podman-systemd.yml
   when:
     - kolla_container_engine == 'podman'
     - kolla_podman_use_systemd | bool
 
 - import_tasks: check-containers.yml
-  when:
-    - kolla_container_engine == 'podman'
-    - kolla_podman_use_systemd | bool
+
+- name: Flush Handlers
+  meta: flush_handlers
 
 - import_tasks: post-config.yml

--- a/doc/source/reference/networking/neutron.rst
+++ b/doc/source/reference/networking/neutron.rst
@@ -173,8 +173,9 @@ mechanism, you can change that using the ``neutron_plugin_agent`` variable in
 On hosts in the ``openvswitch`` group the role creates and starts the
 ``openvswitch-db-server`` and ``openvswitch-vswitchd`` containers.  When
 using Podman their systemd units (``container-openvswitch_db.service`` and
-``container-openvswitch_vswitchd.service``) are generated and enabled.  The
-deployment waits for the Open vSwitch database socket to appear before
+``container-openvswitch_vswitchd.service``) are generated and enabled prior to
+any verification.  The deployment waits for the Open vSwitch database socket to
+appear before
 applying any ``ovs-vsctl`` configuration, so running with
 ``--limit`` still configures the host correctly.  If ``ovs-vsctl`` reports
 ``Connection refused``, verify that the containers are running and that


### PR DESCRIPTION
## Summary
- generate Open vSwitch podman units before running container checks
- flush handlers so containers start before post-config steps
- clarify documentation around podman unit generation and verification order

## Testing
- `ansible-lint ansible/roles/openvswitch/tasks/deploy.yml`
- `doc8 doc/source/reference/networking/neutron.rst`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6899f1d4fb9483278854e7662b1cda13