### PR TITLE
openvswitch: ensure containers exist before verify

### DIFF
--- a/ansible/roles/openvswitch/tasks/deploy.yml
+++ b/ansible/roles/openvswitch/tasks/deploy.yml
@@ -6,7 +6,8 @@
 - import_tasks: podman-systemd.yml
   when:
     - kolla_container_engine == 'podman'
-    - kolla_podman_use_systemd | bool
+    - enable_openvswitch | bool
+    - openvswitch_services['openvswitch-db-server'].host_in_groups | bool
 
 - import_tasks: check-containers.yml
 

--- a/ansible/roles/openvswitch/tasks/post-config.yml
+++ b/ansible/roles/openvswitch/tasks/post-config.yml
@@ -1,5 +1,21 @@
 ---
 # NOTE(mnasiadka): external_ids:system-id uniquely identifies a physical system, used by OVN and other controllers
+- name: Wait for openvswitch_db container
+  become: true
+  kolla_container_facts:
+    action: get_containers
+    container_engine: "{{ kolla_container_engine }}"
+    name:
+      - openvswitch_db
+  register: ovsdb_container
+  changed_when: false
+  failed_when: false
+  retries: 10
+  delay: 3
+  until: ovsdb_container.containers.openvswitch_db is defined
+  when:
+    - openvswitch_services['openvswitch-vswitchd'].host_in_groups | bool
+
 - name: Wait for Open vSwitch database socket
   become: true
   command: "{{ kolla_container_engine }} exec openvswitch_db ovsdb-client list-dbs"
@@ -10,6 +26,7 @@
   until: ovsdb_wait.rc == 0
   when:
     - openvswitch_services['openvswitch-vswitchd'].host_in_groups | bool
+    - ovsdb_container.containers.openvswitch_db is defined
 
 - name: Set system-id, hostname and hw-offload
   become: true

--- a/ansible/roles/service-check-containers/tasks/verify.yml
+++ b/ansible/roles/service-check-containers/tasks/verify.yml
@@ -77,46 +77,48 @@
     needs_start: >-
       {{ container_result.rc != 0 or (unit_file.stat.exists and (not unit_enabled or unit_active.rc | default(3) != 0)) }}
 
-- name: Detect health-check drift
-  set_fact:
-    container_needs_recreate: true
-  when:
-    - not container_missing
-    - (container_inspect.Config.Healthcheck.Test | default([]) | to_json)
-      != (desired_healthcheck_test | to_json)
+- block:
+    - name: Detect health-check drift
+      set_fact:
+        container_needs_recreate: true
+      when:
+        - not container_missing
+        - (container_inspect.Config.Healthcheck.Test | default([]) | to_json)
+          != (desired_healthcheck_test | to_json)
 
-- name: Init service fact for handlers
-  set_fact:
-    service: "{{ container_spec | combine({'unit_file_exists': unit_file.stat.exists}) }}"
+    - name: Init service fact for handlers
+      set_fact:
+        service: "{{ container_spec | combine({'unit_file_exists': unit_file.stat.exists}) }}"
 
-- name: Clear host error state
-  meta: clear_host_errors
+    - name: Clear host error state
+      meta: clear_host_errors
 
-- name: Notify recreate handler when needed
-  debug:
-    msg: "Scheduling container recreation"
-  changed_when: true
-  when: (container_missing | bool or container_needs_recreate | bool) and unit_enabled | bool
-  notify: Recreate container
+    - name: Notify recreate handler when needed
+      debug:
+        msg: "Scheduling container recreation"
+      changed_when: true
+      when: (container_missing | bool or container_needs_recreate | bool) and unit_enabled | bool
+      notify: Recreate container
 
-- name: Notify restart when needed
-  debug:
-    msg: Notifying restart handler
-  changed_when: needs_start | bool and not container_needs_recreate | bool
-  notify: "Restart container"
-  when: not container_needs_recreate | bool
+    - name: Notify restart when needed
+      debug:
+        msg: Notifying restart handler
+      changed_when: needs_start | bool and not container_needs_recreate | bool
+      notify: "Restart container"
+      when: not container_needs_recreate | bool
 
-- name: Flush restart handler
-  meta: flush_handlers
+    - name: Flush restart handler
+      meta: flush_handlers
 
-- name: Ensure unit running when container exists
-  become: true
-  systemd:
-    name: "{{ unit_name }}"
-    state: restarted
-    enabled: true
-  when:
-    - not container_missing
-    - unit_file.stat.exists
-    - kolla_container_engine == 'docker' or kolla_podman_use_systemd | bool
-    - (unit_active.rc | default(0)) != 0
+    - name: Ensure unit running when container exists
+      become: true
+      systemd:
+        name: "{{ unit_name }}"
+        state: restarted
+        enabled: true
+      when:
+        - not container_missing
+        - unit_file.stat.exists
+        - kolla_container_engine == 'docker' or kolla_podman_use_systemd | bool
+        - (unit_active.rc | default(0)) != 0
+  when: not (container_missing | bool and not unit_file.stat.exists)

--- a/doc/source/reference/networking/neutron.rst
+++ b/doc/source/reference/networking/neutron.rst
@@ -181,6 +181,11 @@ applying any ``ovs-vsctl`` configuration, so running with
 ``Connection refused``, verify that the containers are running and that
 ``/run/openvswitch/db.sock`` exists.
 
+Verification of the Open vSwitch containers only proceeds when the
+corresponding systemd unit or container is present.  If neither exists, the
+check is skipped entirely, avoiding spurious failures on hosts where the role
+is not enabled.
+
 When using Open vSwitch on a compatible kernel (4.3+ upstream, consult the
 documentation of your distribution for support details), you can switch
 to using the native OVS firewall driver by employing a configuration override


### PR DESCRIPTION
## Summary
- generate Open vSwitch Podman units whenever the service is enabled
- wait for `openvswitch_db` container before running database health checks
- skip container verify steps when neither unit nor container is present
- document that verification is skipped if Open vSwitch isn’t enabled on the host

## Testing
- `ansible-lint ansible/roles/openvswitch/tasks/deploy.yml ansible/roles/openvswitch/tasks/post-config.yml ansible/roles/service-check-containers/tasks/verify.yml`
- `tox -e linters` *(fails: yaml key-duplicates, yaml indentation, var-naming, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6899fcad47048327b54c6661bc83e135