### PR TITLE
Fix openvswitch agent config condition for OVS cleanup

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -284,8 +284,8 @@
     dest: "{{ node_config_directory }}/{{ service_name }}/openvswitch_agent.ini"
     mode: "0660"
   when:
-    - neutron_services['neutron-metadata-agent']['enabled'] | bool
-    - inventory_hostname in groups['neutron-metadata-agent']
+    - neutron_services['neutron-openvswitch-agent']['enabled'] | bool
+    - inventory_hostname in groups['neutron-openvswitch-agent']
 
 
 - name: Ensure sriov agent config dir exists

--- a/releasenotes/notes/ovs-cleanup-openvswitch-agent-cond-fix-2025.yaml
+++ b/releasenotes/notes/ovs-cleanup-openvswitch-agent-cond-fix-2025.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Generate ``openvswitch_agent.ini`` only when the
+    ``neutron-openvswitch-agent`` is enabled. Previously the task checked
+    the metadata agent instead, which could skip creation of the
+    configuration file and break the ``neutron-ovs-cleanup`` container
+    deployment.
+


### PR DESCRIPTION
## Summary
- ensure openvswitch_agent.ini is generated when neutron-openvswitch-agent is enabled
- document fix for neutron-ovs-cleanup configuration generation

## Testing
- `tox -e linters` *(fails: yaml formatting issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689b209a89488327812a65e8693f0486