### PR TITLE
service start order wait for container health

### DIFF
--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -15,6 +15,15 @@ kolla_service_start_priority:
   - collectd
 
 #####################
+# Service start wait behaviour
+#####################
+# Timeout applied to systemd services while waiting for dependency health.
+# Set to 0 to disable the timeout.
+kolla_service_start_timeout: 0
+# Delay applied when a dependency has no container healthcheck.
+kolla_service_no_healthcheck_wait: 30
+
+#####################
 # OVS cleanup
 #####################
 # Marker file used to ensure neutron_ovs_cleanup runs only once per boot

--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -29,7 +29,17 @@
     dest: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item.1 }}{{ kolla_service_unit_suffix }}.service.d/start-order.conf"
     mode: "0644"
   loop: "{{ start_order_pairs }}"
+  register: start_order_override_result
   notify: Reload systemd
+
+- name: Restart services if start order changed
+  become: true
+  systemd:
+    name: "{{ kolla_service_unit_prefix }}{{ item.item.1 }}{{ kolla_service_unit_suffix }}.service"
+    state: restarted
+    daemon_reload: yes
+  loop: "{{ start_order_override_result.results | selectattr('changed') | list }}"
+  when: start_order_override_result is defined
 
 - name: Start compute services in order
   include_tasks: start_service.yml

--- a/ansible/roles/service-start-order/templates/start-order.conf.j2
+++ b/ansible/roles/service-start-order/templates/start-order.conf.j2
@@ -3,15 +3,25 @@ After={{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}
 Requires={{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}.service
 
 [Service]
+TimeoutStartSec={{ kolla_service_start_timeout }}
 ExecStartPre=/bin/sh -c '\
   until systemctl is-active --quiet {{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}.service; do sleep 1; done; \
   if [ "{{ kolla_container_engine }}" = "podman" ]; then \
     {{ kolla_container_engine }} healthcheck run {{ item.0 }} >/dev/null 2>&1; \
     rc=$?; \
     if [ $rc -eq 125 ]; then \
-      sleep 30; \
+      sleep {{ kolla_service_no_healthcheck_wait }}; \
     elif [ $rc -ne 0 ]; then \
       until {{ kolla_container_engine }} healthcheck run {{ item.0 }} >/dev/null 2>&1; do sleep 1; done; \
     fi; \
+  elif [ "{{ kolla_container_engine }}" = "docker" ]; then \
+    has_hc=$({{ kolla_container_engine }} inspect --format='{{"{{"}}json .Config.Healthcheck{{"}}"}}' {{ item.0 }}); \
+    if [ "$has_hc" = "null" ] || [ -z "$has_hc" ]; then \
+      sleep {{ kolla_service_no_healthcheck_wait }}; \
+    else \
+      until [ "$({{ kolla_container_engine }} inspect --format='{{"{{"}}.State.Health.Status{{"}}"}}' {{ item.0 }})" = "healthy" ]; do sleep 1; done; \
+    fi; \
+  else \
+    sleep {{ kolla_service_no_healthcheck_wait }}; \
   fi; \
   exit 0'

--- a/molecule/service_start_order/verify.yml
+++ b/molecule/service_start_order/verify.yml
@@ -16,6 +16,7 @@
         that:
           - "'After=container-c1.service' in content"
           - "'Requires=container-c1.service' in content"
+          - "'TimeoutStartSec=0' in content"
           - "'ExecStartPre=/bin/sh -c' in content"
           - "'systemctl is-active --quiet container-c1.service' in content"
           - "'podman healthcheck run c1' in content"

--- a/releasenotes/notes/health-gated-start-order-b5b750d1fd4c1c5d.yaml
+++ b/releasenotes/notes/health-gated-start-order-b5b750d1fd4c1c5d.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Service start ordering now waits for dependency health checks and sets
+    ``TimeoutStartSec`` via ``kolla_service_start_timeout``. A fallback delay
+    ``kolla_service_no_healthcheck_wait`` controls waits for dependencies
+    without health checks.
+upgrade:
+  - |
+    Services managed by ``service-start-order`` now default to
+    ``TimeoutStartSec=0`` to avoid premature start failure while waiting for
+    dependencies to become healthy. Operators may adjust this with
+    ``kolla_service_start_timeout``.


### PR DESCRIPTION
## Summary
- standardize service start order health gating
- document health-gated start order and new variables

## Testing
- `tox -e linters` (fails: Duplicate keys, jinja errors, yaml formatting)
- `tox -e docs`


------
https://chatgpt.com/codex/tasks/task_e_689b2afe0e808327a06ab639e4456560