### PR TITLE
ceilometer: skip notification event files when service absent

### DIFF
--- a/ansible/roles/ceilometer/tasks/config.yml
+++ b/ansible/roles/ceilometer/tasks/config.yml
@@ -190,6 +190,11 @@
   delegate_to: localhost
   register: ceilometer_event_definitions_file
 
+- name: Check notification config directory exists
+  stat:
+    path: "{{ node_config_directory }}/ceilometer-notification"
+  register: ceilometer_notification_conf_dir
+
 - name: Copying over event_definitions.yaml
   vars:
     service: "{{ ceilometer_services['ceilometer-notification'] }}"
@@ -203,6 +208,7 @@
   when:
     - ceilometer_event_definitions_file.stat.exists
     - service | service_enabled_and_mapped_to_host
+    - ceilometer_notification_conf_dir.stat.exists
 
 - name: Copying over event_definitions.yaml for notification service
   vars:
@@ -215,6 +221,7 @@
   register: ceilometer_event_definitions
   when:
     - service | service_enabled_and_mapped_to_host
+    - ceilometer_notification_conf_dir.stat.exists
     - not ceilometer_event_definitions_file.stat.exists
 
 - name: Copying over event_pipeline.yaml
@@ -228,7 +235,9 @@
     dest: "{{ node_config_directory }}/ceilometer-notification/event_pipeline.yaml"
     mode: "0660"
   become: true
-  when: service | service_enabled_and_mapped_to_host
+  when:
+    - service | service_enabled_and_mapped_to_host
+    - ceilometer_notification_conf_dir.stat.exists
 
 - name: Check custom pipeline.yaml exists
   stat:

--- a/releasenotes/notes/ceilometer-notification-event-defs-skip.yaml
+++ b/releasenotes/notes/ceilometer-notification-event-defs-skip.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Prevent Ceilometer deployment failures when the
+    ``ceilometer-notification`` service is not mapped to a host by
+    skipping event definition and event pipeline configuration if the
+    service configuration directory is absent.


### PR DESCRIPTION
## Summary
- avoid copying Ceilometer event definitions and pipeline when ceilometer-notification is not deployed
- add release note

## Testing
- `tox -e linters` *(fails: yaml and jinja lint issues elsewhere in tree)*

------
https://chatgpt.com/codex/tasks/task_e_689b31b370ac83279e10d161946001f5