### PR TITLE
Ensure secrets copied with secure permissions

### DIFF
--- a/ansible/roles/distribute-secrets/tasks/process_group.yml
+++ b/ansible/roles/distribute-secrets/tasks/process_group.yml
@@ -15,7 +15,15 @@
     dest: "{{ kolla_secrets_dest }}/{{ group }}/{{ item.path | basename }}"
     owner: root
     group: root
-    mode: "{{ item.mode if (item.mode | int(base=8)) <= 420 else '0644' }}"
+    mode: >-
+      {% set filename = item.path | basename %}
+      {% if filename == 'known_hosts' or filename.endswith('.pub') %}
+      0644
+      {% elif filename | regex_search('.*(_rsa|_dsa|_ed25519|_ecdsa|_key)$') %}
+      0600
+      {% else %}
+      {{ item.mode if (item.mode | int(base=8)) <= 420 else '0644' }}
+      {% endif %}
   loop: "{{ kolla_secret_files.get(group, []) }}"
   loop_control:
     label: "{{ item.path | basename }}"

--- a/doc/source/reference/deployment-and-bootstrapping/distribute-secrets.rst
+++ b/doc/source/reference/deployment-and-bootstrapping/distribute-secrets.rst
@@ -1,0 +1,36 @@
+============================
+Distributing Kolla secrets
+============================
+
+Kolla Ansible can distribute service specific secret files from the deploy host
+to target nodes as part of the ``bootstrap-servers`` play. Files placed under
+``/etc/kolla/config/secrets/<group>/`` on the control host will be copied to
+``/etc/kolla/secrets/<group>/`` on hosts that belong to the matching inventory
+group.
+
+The source and destination directories can be customised with the variables
+``kolla_secrets_src`` (default ``/etc/kolla/config/secrets``) and
+``kolla_secrets_dest`` (default ``/etc/kolla/secrets``).
+
+Destination directories are created with permissions ``0700``. Private keys
+such as ``gitlab_key`` are written with mode ``0600``. Public keys and files
+like ``known_hosts`` are written with mode ``0644``.
+
+Example:
+
+.. code-block:: text
+
+    /etc/kolla/config/secrets/compute/gitlab_key
+    /etc/kolla/config/secrets/compute/gitlab_key.pub
+    /etc/kolla/config/secrets/compute/known_hosts
+
+After running ``kolla-ansible bootstrap-servers`` the files will be available
+on all hosts in the ``compute`` group:
+
+.. code-block:: text
+
+    /etc/kolla/secrets/compute/gitlab_key
+    /etc/kolla/secrets/compute/gitlab_key.pub
+    /etc/kolla/secrets/compute/known_hosts
+
+Empty secret directories are skipped but a debug message is logged.

--- a/doc/source/reference/deployment-and-bootstrapping/index.rst
+++ b/doc/source/reference/deployment-and-bootstrapping/index.rst
@@ -10,3 +10,4 @@ hosts.
 
    bifrost
    bootstrap-servers
+   distribute-secrets


### PR DESCRIPTION
## Summary
- enforce secure permissions when distributing secret files
- document secret distribution and configuration variables

## Testing
- `tox -e linters` *(fails: Rule Violation Summary...)*


------
https://chatgpt.com/codex/tasks/task_e_689b3a400ec4832788e94159ffe15041