### PR TITLE
Distribute secrets during deploy

### DIFF
--- a/ansible/distribute-secrets.yml
+++ b/ansible/distribute-secrets.yml
@@ -1,0 +1,11 @@
+---
+- import_playbook: gather-facts.yml
+
+- name: Distribute service secrets
+  hosts: all
+  serial: '{{ kolla_serial|default("0") }}'
+  gather_facts: false
+  max_fail_percentage: >-
+    {{ secrets_max_fail_percentage | default(kolla_max_fail_percentage) | default(100) }}
+  roles:
+    - distribute-secrets

--- a/ansible/roles/distribute-secrets/defaults/main.yml
+++ b/ansible/roles/distribute-secrets/defaults/main.yml
@@ -1,3 +1,4 @@
 # Defaults for distribute-secrets role
 kolla_secrets_src: /etc/kolla/config/secrets
 kolla_secrets_dest: /etc/kolla/secrets
+kolla_secrets_group_map: {}

--- a/ansible/roles/distribute-secrets/tasks/main.yml
+++ b/ansible/roles/distribute-secrets/tasks/main.yml
@@ -81,25 +81,30 @@
     kolla_secret_files: "{{ hostvars['localhost'].kolla_secret_files | default({}) }}"
   loop: "{{ ansible_play_hosts_all }}"
 
-- name: Process secrets for host groups
+- name: Process secrets for directories
   include_tasks: process_group.yml
-  when: (kolla_secret_files | default({})).get(group, []) | length > 0
   vars:
     inventory_meta_groups: "{{ ['all', 'ungrouped'] + (groups.keys() | select('match','^all_') | list) }}"
     my_groups: "{{ group_names | difference(inventory_meta_groups) }}"
-  loop: "{{ my_groups }}"
+    group: "{{ secret_dir }}"
+  when: >-
+    (kolla_secret_files | default({})).get(secret_dir, []) | length > 0 and
+    (kolla_secrets_group_map.get(secret_dir, [secret_dir]) | intersect(my_groups)) | length > 0
+  loop: "{{ kolla_secret_files.keys() | list }}"
   loop_control:
-    loop_var: group
-    label: "{{ group }}"
+    loop_var: secret_dir
+    label: "{{ secret_dir }}"
 
-- name: Debug groups skipped
+- name: Debug secrets directories skipped
   debug:
-    msg: "No secrets found for group {{ group }} - skipping"
-  when: (kolla_secret_files | default({})).get(group, []) | length == 0
+    msg: "No secrets found for directory {{ secret_dir }} - skipping"
   vars:
     inventory_meta_groups: "{{ ['all', 'ungrouped'] + (groups.keys() | select('match','^all_') | list) }}"
     my_groups: "{{ group_names | difference(inventory_meta_groups) }}"
-  loop: "{{ my_groups }}"
+  when: >-
+    (kolla_secret_files | default({})).get(secret_dir, []) | length > 0 and
+    (kolla_secrets_group_map.get(secret_dir, [secret_dir]) | intersect(my_groups)) | length == 0
+  loop: "{{ kolla_secret_files.keys() | list }}"
   loop_control:
-    loop_var: group
-    label: "{{ group }}"
+    loop_var: secret_dir
+    label: "{{ secret_dir }}"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -73,6 +73,19 @@
         - enable_zun_{{ enable_zun | bool }}
   tags: always
 
+- name: Distribute service secrets
+  hosts:
+    - kolla_action_deploy
+    - kolla_action_deploy-containers
+    - kolla_action_reconfigure
+    - kolla_action_upgrade
+  gather_facts: false
+  serial: '{{ kolla_serial|default("0") }}'
+  max_fail_percentage: >-
+    {{ secrets_max_fail_percentage | default(kolla_max_fail_percentage) | default(100) }}
+  roles:
+    - distribute-secrets
+
 - name: Apply role prechecks
   gather_facts: false
   # Apply only when kolla action is 'precheck'.

--- a/distribute-kolla-secrets.md
+++ b/distribute-kolla-secrets.md
@@ -2,13 +2,17 @@
 
 This feature allows administrators to organise service specific secret files on
 the deploy host and automatically distribute them to the correct hosts during
-`kolla-ansible bootstrap-servers`.
+`kolla-ansible bootstrap-servers`, `deploy`, `deploy-containers`,
+`reconfigure` and `upgrade`.
 
 ## Organising Secrets
 
 On the deploy host place files under `/etc/kolla/config/secrets/<group>/` where
 `<group>` matches an inventory group name. All files in such a directory will be
 copied to `/etc/kolla/secrets/<group>/` on hosts belonging to that group.
+Secret directories can be mapped to multiple inventory groups via the
+`kolla_secrets_group_map` variable when the directory name does not match the
+group.
 
 Example:
 
@@ -16,19 +20,20 @@ Example:
 /etc/kolla/config/secrets/nova/gitlab_key.pub
 ```
 
-After running `kolla-ansible bootstrap-servers` the file will be available on
-all hosts in the `nova` group as:
+After running any of the above commands the file will be available on all hosts
+in the `nova` group as:
 
 ```text
 /etc/kolla/secrets/nova/gitlab_key.pub
 ```
 
-## Integration with bootstrap-servers
+## Integration with kolla-ansible
 
-No additional commands are required. When `bootstrap-servers` runs it now calls
+No additional commands are required. When the listed commands run they now call
 an additional role that performs the distribution. The destination directory is
 created with `0700` permissions and files default to `0644`. More restrictive
-source permissions such as `0600` are preserved.
+source permissions such as `0600` are preserved. The distribution may also be
+triggered manually using `kolla-ansible distribute-secrets`.
 
 Empty directories are skipped with a debug message and directories that do not
 exist are silently ignored. The tasks are idempotent and safe to run multiple

--- a/doc/source/reference/deployment-and-bootstrapping/distribute-secrets.rst
+++ b/doc/source/reference/deployment-and-bootstrapping/distribute-secrets.rst
@@ -3,14 +3,18 @@ Distributing Kolla secrets
 ============================
 
 Kolla Ansible can distribute service specific secret files from the deploy host
-to target nodes as part of the ``bootstrap-servers`` play. Files placed under
-``/etc/kolla/config/secrets/<group>/`` on the control host will be copied to
-``/etc/kolla/secrets/<group>/`` on hosts that belong to the matching inventory
-group.
+to target nodes. Secrets are synchronised automatically during
+``bootstrap-servers``, ``deploy``, ``deploy-containers``, ``reconfigure`` and
+``upgrade``. Files placed under ``/etc/kolla/config/secrets/<group>/`` on the
+control host will be copied to ``/etc/kolla/secrets/<group>/`` on hosts that
+belong to the matching inventory group.
 
 The source and destination directories can be customised with the variables
 ``kolla_secrets_src`` (default ``/etc/kolla/config/secrets``) and
 ``kolla_secrets_dest`` (default ``/etc/kolla/secrets``).
+Secret directories are matched to inventory groups based on their name. This
+behaviour can be overridden with ``kolla_secrets_group_map`` which maps a
+secret directory to one or more inventory groups.
 
 Destination directories are created with permissions ``0700``. Private keys
 such as ``gitlab_key`` are written with mode ``0600``. Public keys and files
@@ -24,8 +28,8 @@ Example:
     /etc/kolla/config/secrets/compute/gitlab_key.pub
     /etc/kolla/config/secrets/compute/known_hosts
 
-After running ``kolla-ansible bootstrap-servers`` the files will be available
-on all hosts in the ``compute`` group:
+When executing any of the above commands the files will be available on all
+hosts in the ``compute`` group:
 
 .. code-block:: text
 
@@ -33,4 +37,6 @@ on all hosts in the ``compute`` group:
     /etc/kolla/secrets/compute/gitlab_key.pub
     /etc/kolla/secrets/compute/known_hosts
 
-Empty secret directories are skipped but a debug message is logged.
+Empty secret directories are skipped but a debug message is logged. The
+distribution can also be triggered manually using the
+``kolla-ansible distribute-secrets`` command.

--- a/kolla_ansible/cli/commands.py
+++ b/kolla_ansible/cli/commands.py
@@ -228,6 +228,20 @@ class OctaviaCertificates(KollaAnsibleMixin, Command):
         self.run_playbooks(parsed_args, playbooks, extra_vars=extra_vars)
 
 
+class DistributeSecrets(KollaAnsibleMixin, Command):
+    """Distribute service specific secrets to hosts"""
+
+    def take_action(self, parsed_args):
+        self.app.LOG.info("Distributing service secrets")
+
+        extra_vars = {}
+        extra_vars["kolla_action"] = "distribute-secrets"
+
+        playbooks = _choose_playbooks(parsed_args, "distribute-secrets")
+
+        self.run_playbooks(parsed_args, playbooks, extra_vars=extra_vars)
+
+
 class Deploy(KollaAnsibleMixin, Command):
     """Generate config, bootstrap and start all Kolla Ansible containers"""
 

--- a/molecule/distribute-secrets/molecule.yml
+++ b/molecule/distribute-secrets/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: instance
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_SCENARIO_DIRECTORY}/playbook.yml
+    verify: ${MOLECULE_SCENARIO_DIRECTORY}/verify.yml
+scenario:
+  test_sequence:
+    - converge
+    - idempotence
+    - verify

--- a/molecule/distribute-secrets/playbook.yml
+++ b/molecule/distribute-secrets/playbook.yml
@@ -1,0 +1,44 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: false
+  vars:
+    groups:
+      compute-kvm:
+        - localhost
+    group_names:
+      - compute-kvm
+    kolla_secrets_src: /tmp/kolla/config/secrets
+    kolla_secrets_dest: /tmp/kolla/secrets
+    kolla_secrets_group_map:
+      compute:
+        - compute
+        - compute-kvm
+  tasks:
+    - name: Prepare secret source directory
+      file:
+        path: "{{ kolla_secrets_src }}/compute"
+        state: directory
+        mode: '0700'
+      delegate_to: localhost
+      run_once: true
+
+    - name: Create private key
+      copy:
+        dest: "{{ kolla_secrets_src }}/compute/gitlab_key"
+        content: dummy
+        mode: '0600'
+      delegate_to: localhost
+      run_once: true
+
+    - name: Create public key
+      copy:
+        dest: "{{ kolla_secrets_src }}/compute/gitlab_key.pub"
+        content: dummy
+        mode: '0644'
+      delegate_to: localhost
+      run_once: true
+
+    - name: Run distribute-secrets role
+      include_role:
+        name: distribute-secrets

--- a/molecule/distribute-secrets/verify.yml
+++ b/molecule/distribute-secrets/verify.yml
@@ -1,0 +1,28 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  vars:
+    kolla_secrets_dest: /tmp/kolla/secrets
+  tasks:
+    - name: Stat private key
+      stat:
+        path: "{{ kolla_secrets_dest }}/compute/gitlab_key"
+      register: priv
+
+    - name: Assert private key
+      assert:
+        that:
+          - priv.stat.exists
+          - priv.stat.mode == '0600'
+
+    - name: Stat public key
+      stat:
+        path: "{{ kolla_secrets_dest }}/compute/gitlab_key.pub"
+      register: pub
+
+    - name: Assert public key
+      assert:
+        that:
+          - pub.stat.exists
+          - pub.stat.mode == '0644'

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ kolla_ansible.cli =
     pull = kolla_ansible.cli.commands:Pull
     certificates = kolla_ansible.cli.commands:Certificates
     octavia-certificates = kolla_ansible.cli.commands:OctaviaCertificates
+    distribute-secrets = kolla_ansible.cli.commands:DistributeSecrets
     deploy = kolla_ansible.cli.commands:Deploy
     deploy-containers = kolla_ansible.cli.commands:DeployContainers
     post-deploy = kolla_ansible.cli.commands:Postdeploy


### PR DESCRIPTION
## Summary
- distribute service secrets on deploy, reconfigure and upgrade
- allow mapping secret directories to multiple inventory groups
- expose `kolla-ansible distribute-secrets` command and document usage

## Testing
- `flake8 kolla_ansible/cli/commands.py`
- `doc8 doc/source/reference/deployment-and-bootstrapping/distribute-secrets.rst`
- `tox -e py3` *(fails: The docker dimension unit [e] is not supported for the dimension [2E])*
- `molecule test -s distribute-secrets` *(fails: Failed to find driver delegated)*

------
https://chatgpt.com/codex/tasks/task_e_689b426fa6d88327b17bd446b372e873