### PR TITLE
Start containers immediately after (re)create

### DIFF
--- a/ansible/library/kolla_container.py
+++ b/ansible/library/kolla_container.py
@@ -431,7 +431,12 @@ def main():
         # types. If we ever add method that will have to return some
         # meaningful data, we need to refactor all methods to return dicts.
         action = module.params.get('action')
-        result = bool(getattr(cw, action)())
+        if action == 'create_container':
+            result = bool(cw.create_container())
+            if cw.changed:
+                cw.start_container()
+        else:
+            result = bool(getattr(cw, action)())
         diff = cw.result.get('diff')
         if action == 'compare_container':
             changed = cw.changed

--- a/ansible/module_utils/kolla_docker_worker.py
+++ b/ansible/module_utils/kolla_docker_worker.py
@@ -366,7 +366,7 @@ class DockerWorker(ContainerWorker):
             if container:
                 self.stop_container()
                 self.remove_container()
-            self.create_container()
+            self.start_container()
 
     def start_container(self):
         if not self.check_image():

--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -530,7 +530,7 @@ class PodmanWorker(ContainerWorker):
             if container:
                 self.stop_container()
                 self.remove_container()
-            self.create_container()
+            self.start_container()
 
     def start_container(self):
         self.ensure_image()

--- a/tests/kolla_container_tests/test_docker_worker.py
+++ b/tests/kolla_container_tests/test_docker_worker.py
@@ -404,6 +404,13 @@ class TestContainer(base.BaseTestCase):
         self.dw.create_volume.assert_has_calls(expected_calls, any_order=True)
         self.assertEqual(self.dw.create_volume.call_count, 2)
 
+    def test_recreate_container_starts(self):
+        self.dw = get_DockerWorker(self.fake_data['params'])
+        self.dw.check_container = mock.MagicMock(return_value=None)
+        self.dw.start_container = mock.MagicMock()
+        self.dw.recreate_container()
+        self.dw.start_container.assert_called_once()
+
     def test_start_container_without_pull(self):
         self.fake_data['params'].update({'auth_username': 'fake_user',
                                          'auth_password': 'fake_psw',

--- a/tests/kolla_container_tests/test_podman_worker.py
+++ b/tests/kolla_container_tests/test_podman_worker.py
@@ -306,6 +306,13 @@ class TestContainer(base.BaseTestCase):
         self.pw.create_volume.assert_has_calls(expected_calls, any_order=True)
         self.assertEqual(self.pw.create_volume.call_count, 2)
 
+    def test_recreate_container_starts(self):
+        self.pw = get_PodmanWorker(self.fake_data['params'])
+        self.pw.get_container_info = mock.MagicMock(return_value=None)
+        self.pw.start_container = mock.MagicMock()
+        self.pw.recreate_container()
+        self.pw.start_container.assert_called_once()
+
     def test_start_container_without_pull(self):
         self.fake_data['params'].update({'auth_username': 'fake_user',
                                          'auth_password': 'fake_psw',


### PR DESCRIPTION
## Summary
- ensure containers are started when recreated for both Docker and Podman workers
- start containers on `create_container` action
- add unit tests covering immediate start behaviour

## Testing
- `python3 -m pytest tests/kolla_container_tests/test_docker_worker.py tests/kolla_container_tests/test_podman_worker.py -k test_recreate_container_starts`

------
https://chatgpt.com/codex/tasks/task_e_689b54a958c48327b877095c40a1eabf