### PR TITLE
Fix handler container start-before-wait and improve diagnostics

### DIFF
--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -39,15 +39,16 @@ Handler auto-start
 
 Containers recreated from Ansible handlers now start immediately unless
 ``defer_start: true`` is specified. When ``wait: true`` is also passed the
-handler waits for the container to reach the running and healthy state
-before continuing.
+handler first ensures the container is started and then waits for it to
+reach the running and healthy state before continuing.
 
 Troubleshooting
 ---------------
 
 If a handler times out and the container remains in ``created`` state,
-the failure message includes ``podman inspect`` state information and the
-last log lines to aid debugging.
+the failure message reports whether a start was attempted, includes
+``podman inspect`` state information and shows the last log lines to
+aid debugging.
 
 One-shot cleanup containers
 ---------------------------

--- a/releasenotes/notes/handler-start-before-wait.yaml
+++ b/releasenotes/notes/handler-start-before-wait.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Ensure containers recreated by handlers are started before waiting
+    and attempt a final start if a container remains in ``created``
+    state. Failure diagnostics now report whether a start was attempted
+    and its result.


### PR DESCRIPTION
## Summary
- ensure containers are started before waiting for readiness
- add final start attempt for "created" containers and expose start results
- document handler auto-start and diagnostics

## Testing
- `pytest tests/test_kolla_container_podman.py::test_start_before_wait tests/test_kolla_container_podman.py::test_wait_triggers_start tests/test_kolla_container_podman.py::test_wait_overrides_defer_start -q`


------
https://chatgpt.com/codex/tasks/task_e_689b5e3b4fd88327a62ed3a2c5179c99