### PR TITLE
Handle Podman-started containers in start-order

### DIFF
--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -14,6 +14,11 @@ kolla_service_start_priority:
   - ceilometer_compute
   - collectd
 
+# Containers recreated during the playbook run and started directly via
+# ``podman start``. These are restarted under systemd exactly once when the
+# ``service-start-order`` role executes.
+kolla_changed_containers: []
+
 #####################
 # Service start wait behaviour
 #####################

--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -32,14 +32,41 @@
   register: start_order_override_result
   notify: Reload systemd
 
+- name: Build restart list for changed overrides
+  set_fact:
+    start_order_restart_services: "{{ start_order_override_result.results | selectattr('changed') | map(attribute='item.1') | list }}"
+  when: start_order_override_result is defined
+
 - name: Restart services if start order changed
   become: true
-  systemd:
-    name: "{{ kolla_service_unit_prefix }}{{ item.item.1 }}{{ kolla_service_unit_suffix }}.service"
-    state: restarted
-    daemon_reload: yes
-  loop: "{{ start_order_override_result.results | selectattr('changed') | list }}"
-  when: start_order_override_result is defined
+  vars:
+    restart_services: "{{ (start_order_restart_services | default([])) | difference(kolla_changed_containers | default([])) }}"
+  loop: "{{ restart_services }}"
+  loop_control:
+    loop_var: svc
+    label: "{{ svc }}"
+  block:
+    - name: Restart {{ svc }} service
+      systemd:
+        name: "{{ kolla_service_unit_prefix }}{{ svc }}{{ kolla_service_unit_suffix }}.service"
+        state: restarted
+        daemon_reload: yes
+      register: restart_result
+  rescue:
+    - name: Show {{ svc }} service status
+      command: "systemctl status {{ kolla_service_unit_prefix }}{{ svc }}{{ kolla_service_unit_suffix }}.service"
+      register: restart_status
+      ignore_errors: true
+    - name: Show {{ svc }} service journal
+      command: "journalctl -u {{ kolla_service_unit_prefix }}{{ svc }}{{ kolla_service_unit_suffix }}.service -n 100"
+      register: restart_journal
+      ignore_errors: true
+    - name: Fail restarting {{ svc }}
+      fail:
+        msg: "Failed to restart {{ svc }} service"
+        data:
+          status: "{{ restart_status.stdout }}"
+          journal: "{{ restart_journal.stdout }}"
 
 - name: Start compute services in order
   include_tasks: start_service.yml

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -11,15 +11,44 @@
     path: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
   register: service_unit
 
+- name: Stop Podman-started {{ item }} container
+  become: true
+  command: "podman stop {{ item }}"
+  register: podman_stop
+  changed_when: podman_stop.rc == 0
+  failed_when: podman_stop.rc not in [0, 125]
+  when:
+    - kolla_container_engine == 'podman'
+    - item in kolla_changed_containers
+    - service_unit.stat.exists
+
 - name: Start {{ item }} service
   become: true
-  systemd:
-    name: "{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
-    state: started
-    enabled: true
-  when:
-    - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
-    - service_unit.stat.exists
+  block:
+    - name: Start {{ item }} via systemd
+      systemd:
+        name: "{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+        state: started
+        enabled: true
+      register: start_result
+      when:
+        - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
+        - service_unit.stat.exists
+  rescue:
+    - name: Show {{ item }} service status
+      command: "systemctl status {{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
+      register: start_status
+      ignore_errors: true
+    - name: Show {{ item }} service journal
+      command: "journalctl -u {{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service -n 100"
+      register: start_journal
+      ignore_errors: true
+    - name: Fail starting {{ item }}
+      fail:
+        msg: "Failed to start {{ item }} service"
+        data:
+          status: "{{ start_status.stdout }}"
+          journal: "{{ start_journal.stdout }}"
 
 - name: Wait for neutron_ovs_cleanup to finish
   become: true

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -45,6 +45,11 @@ the container is started and then waits for it to reach the running and
 healthy state before continuing. Containers started in this way are still
 recorded for the final ordered restart phase, which uses systemd when
 available to sequence service dependencies.
+During the restart phase the ``service-start-order`` role stops these
+Podman-started containers once and then starts them under systemd using
+``systemctl start container-<name>.service``. This transfers control to
+systemd so that start-order dependencies are honoured. Containers that
+were already managed by systemd are left running and are not restarted.
 
 Troubleshooting
 ---------------

--- a/molecule/service_start_order/playbook.yml
+++ b/molecule/service_start_order/playbook.yml
@@ -32,13 +32,13 @@
       changed_when: c1_run.rc == 0
       failed_when: c1_run.rc not in [0,125]
 
-    - name: Ensure c2 container is running
+    - name: Ensure c2 container exists
       become: true
       command: >-
-        podman run -d --name c2 --health-cmd 'true' --health-interval 1s docker.io/library/busybox:latest tail -f /dev/null
-      register: c2_run
-      changed_when: c2_run.rc == 0
-      failed_when: c2_run.rc not in [0,125]
+        podman create --name c2 --health-cmd 'true' --health-interval 1s docker.io/library/busybox:latest tail -f /dev/null
+      register: c2_create
+      changed_when: c2_create.rc == 0
+      failed_when: c2_create.rc not in [0,125]
 
     - name: Create systemd unit for c1
       become: true
@@ -68,6 +68,36 @@
           [Install]
           WantedBy=multi-user.target
 
+    - name: Start c2 via systemd
+      become: true
+      command: systemctl start container-c2.service
+      register: c2_systemd_start
+      changed_when: c2_systemd_start.rc == 0
+      failed_when: c2_systemd_start.rc != 0
+
+    - name: Record c1 start time
+      become: true
+      command: >-
+        podman inspect c1 --format '{% raw %}{{.State.StartedAt}}{% endraw %}'
+      register: c1_start
+      changed_when: false
+
+    - name: Record c2 start time
+      become: true
+      command: >-
+        podman inspect c2 --format '{% raw %}{{.State.StartedAt}}{% endraw %}'
+      register: c2_start
+      changed_when: false
+
+    - name: Write start times file
+      become: true
+      copy:
+        dest: /tmp/start_times.json
+        content: "{{ {'c1': c1_start.stdout, 'c2': c2_start.stdout} | to_nice_json }}"
+
     - name: Run service-start-order role
       include_role:
         name: service-start-order
+      vars:
+        kolla_changed_containers:
+          - c1

--- a/molecule/service_start_order/verify.yml
+++ b/molecule/service_start_order/verify.yml
@@ -21,3 +21,36 @@
           - "'systemctl is-active --quiet container-c1.service' in content"
           - "'podman healthcheck run c1' in content"
           - "'sleep 30' in content"
+
+    - name: Read recorded start times
+      become: true
+      slurp:
+        path: /tmp/start_times.json
+      register: start_file
+
+    - name: Set start times fact
+      set_fact:
+        start_before: "{{ start_file.content | b64decode | from_json }}"
+
+    - name: Get c1 start time after
+      command: >-
+        podman inspect c1 --format '{% raw %}{{.State.StartedAt}}{% endraw %}'
+      register: c1_after
+      changed_when: false
+
+    - name: Get c2 start time after
+      command: >-
+        podman inspect c2 --format '{% raw %}{{.State.StartedAt}}{% endraw %}'
+      register: c2_after
+      changed_when: false
+
+    - name: Ensure c1 now managed by systemd
+      command: systemctl is-active --quiet container-c1.service
+      register: c1_active
+      failed_when: c1_active.rc != 0
+
+    - name: Assert start times
+      assert:
+        that:
+          - c1_after.stdout != start_before.c1
+          - c2_after.stdout == start_before.c2


### PR DESCRIPTION
## Summary
- track containers that were started directly via Podman
- stop Podman-started containers and start them under systemd during service start-order
- document Podman restart behaviour

## Testing
- `python -m ansiblelint ansible/roles/service-start-order/tasks/deploy.yml ansible/roles/service-start-order/tasks/start_service.yml molecule/service_start_order/playbook.yml molecule/service_start_order/verify.yml`
- `python -m tox -e py3` (fails: The docker dimension unit [e] is not supported for the dimension [2E]. The currently supported units are ['b', 'k', 'm', 'g'].)
- `python -m tox -e linters` (fails: duplicate dict key errors in existing files)
- `python -m molecule test -s service_start_order` (fails: Failed to find driver delegated)


------
https://chatgpt.com/codex/tasks/task_e_689b6b28f0f88327a66af924a5390d29