### PR TITLE
service-start-order: fix restart and diagnostics

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -32,6 +32,9 @@
   register: start_order_override_result
   notify: Reload systemd
 
+- name: Reload systemd after applying overrides
+  meta: flush_handlers
+
 - name: Build restart list for changed overrides
   set_fact:
     start_order_restart_services: "{{ start_order_override_result.results | selectattr('changed') | map(attribute='item.1') | list }}"

--- a/ansible/roles/service-start-order/tasks/restart_service.yml
+++ b/ansible/roles/service-start-order/tasks/restart_service.yml
@@ -6,7 +6,6 @@
   failed_when: podman_stop.rc not in [0, 125]
   when:
     - kolla_container_engine == 'podman'
-    - svc in kolla_changed_containers | default([])
 
 - name: Restart {{ svc }} service
   become: true
@@ -28,7 +27,9 @@
       ignore_errors: true
     - name: Fail restarting {{ svc }}
       fail:
-        msg: "Failed to restart {{ svc }} service"
-        data:
-          status: "{{ restart_status.stdout }}"
-          journal: "{{ restart_journal.stdout }}"
+        msg: |
+          Failed to restart {{ svc }} service
+          Status:
+          {{ restart_status.stdout | default('') }}
+          Journal:
+          {{ restart_journal.stdout | default('') }}

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -19,7 +19,6 @@
   failed_when: podman_stop.rc not in [0, 125]
   when:
     - kolla_container_engine == 'podman'
-    - item in kolla_changed_containers
     - service_unit.stat.exists
 
 - name: Start {{ item }} service
@@ -45,10 +44,12 @@
       ignore_errors: true
     - name: Fail starting {{ item }}
       fail:
-        msg: "Failed to start {{ item }} service"
-        data:
-          status: "{{ start_status.stdout }}"
-          journal: "{{ start_journal.stdout }}"
+        msg: |
+          Failed to start {{ item }} service
+          Status:
+          {{ start_status.stdout | default('') }}
+          Journal:
+          {{ start_journal.stdout | default('') }}
 
 - name: Wait for neutron_ovs_cleanup to finish
   become: true

--- a/ansible/roles/service-start-order/templates/start-order.conf.j2
+++ b/ansible/roles/service-start-order/templates/start-order.conf.j2
@@ -15,11 +15,11 @@ ExecStartPre=/bin/sh -c '\
       until {{ kolla_container_engine }} healthcheck run {{ item.0 }} >/dev/null 2>&1; do sleep 1; done; \
     fi; \
   elif [ "{{ kolla_container_engine }}" = "docker" ]; then \
-    has_hc=$({{ kolla_container_engine }} inspect --format='{{"{{"}}json .Config.Healthcheck{{"}}"}}' {{ item.0 }}); \
+    has_hc=$({{ kolla_container_engine }} inspect --format={{"{{"}}json .Config.Healthcheck{{"}}"}} {{ item.0 }}); \
     if [ "$has_hc" = "null" ] || [ -z "$has_hc" ]; then \
       sleep {{ kolla_service_no_healthcheck_wait }}; \
     else \
-      until [ "$({{ kolla_container_engine }} inspect --format='{{"{{"}}.State.Health.Status{{"}}"}}' {{ item.0 }})" = "healthy" ]; do sleep 1; done; \
+      until [ "$({{ kolla_container_engine }} inspect --format={{"{{"}}.State.Health.Status{{"}}"}} {{ item.0 }})" = "healthy" ]; do sleep 1; done; \
     fi; \
   else \
     sleep {{ kolla_service_no_healthcheck_wait }}; \

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -31,6 +31,9 @@ start sequentially according to ``kolla_service_start_priority``. Each
 service waits for the previous unit to reach the ``active`` state and, if
 a container health check is defined, for that check to succeed. When no
 health indicator exists a 30 second delay is applied before continuing.
+The role reloads systemd after writing any drop-in files so that new
+dependencies are applied immediately. It also stops containers that were
+previously launched directly via Podman and restarts them under systemd.
 This ensures dependencies such as databases and messaging back ends are
 available before the corresponding API services are launched.
 
@@ -57,8 +60,9 @@ Troubleshooting
 
 The final restart sequence relies on systemd unit files when they are
 present. If systemd is unavailable or fails to start a unit, Kolla
-Ansible retries using ``podman start`` and reports the original systemd
-failure along with container logs to aid debugging.
+Ansible reloads systemd units, retries using ``podman start`` and reports
+the original systemd failure along with service status and journal output
+to aid debugging.
 
 One-shot cleanup containers
 ---------------------------


### PR DESCRIPTION
## Summary
- reload systemd after installing start-order drop-ins
- stop podman containers before starting via systemd
- fix health check template quoting and fail module usage
- document service restart behaviour

## Testing
- `ansible-lint ansible/roles/service-start-order/tasks/start_service.yml ansible/roles/service-start-order/tasks/restart_service.yml ansible/roles/service-start-order/tasks/deploy.yml ansible/roles/service-start-order/templates/start-order.conf.j2`
- `tox -e linters` *(fails: ansible-lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c9ef6d48327b299743e83a40233