### PR TITLE
service-start-order: gate restarts on container health

### DIFF
--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -27,6 +27,9 @@ kolla_changed_containers: []
 kolla_service_start_timeout: 0
 # Delay applied when a dependency has no container healthcheck.
 kolla_service_no_healthcheck_wait: 30
+# Attempts and delay for verifying container health after restart/start
+kolla_service_healthcheck_retries: 60
+kolla_service_healthcheck_delay: 2
 
 #####################
 # OVS cleanup

--- a/ansible/roles/service-start-order/tasks/restart_service.yml
+++ b/ansible/roles/service-start-order/tasks/restart_service.yml
@@ -33,3 +33,16 @@
           {{ restart_status.stdout | default('') }}
           Journal:
           {{ restart_journal.stdout | default('') }}
+  always:
+    - name: Wait for {{ svc }} to be running and healthy
+      become: true
+      kolla_container_facts:
+        action: get_containers
+        container_engine: "{{ kolla_container_engine }}"
+        name: "{{ svc }}"
+      register: svc_health
+      retries: "{{ kolla_service_healthcheck_retries }}"
+      delay: "{{ kolla_service_healthcheck_delay }}"
+      until:
+        - svc_health.containers.get(svc, {}).get('State', {}).get('Status') == 'running'
+        - (svc_health.containers.get(svc, {}).get('State', {}).get('Health', {}).get('Status', 'healthy')) == 'healthy'

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -11,6 +11,19 @@
     path: "/etc/systemd/system/{{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
   register: service_unit
 
+- name: Gather {{ item }} container facts
+  become: true
+  kolla_container_facts:
+    action: get_containers
+    container_engine: "{{ kolla_container_engine }}"
+    name: "{{ item }}"
+  register: svc_facts
+
+- name: Evaluate {{ item }} container state
+  set_fact:
+    svc_running: "{{ (item in svc_facts.containers and svc_facts.containers[item]['State']['Status'] == 'running') | bool }}"
+    svc_healthy: "{{ (item in svc_facts.containers and (svc_facts.containers[item]['State']['Health']['Status'] | default('healthy')) == 'healthy') | bool }}"
+
 - name: Stop Podman-started {{ item }} container
   become: true
   command: "podman stop {{ item }}"
@@ -20,6 +33,7 @@
   when:
     - kolla_container_engine == 'podman'
     - service_unit.stat.exists
+    - not (svc_running and svc_healthy)
 
 - name: Start {{ item }} service
   become: true
@@ -33,6 +47,7 @@
       when:
         - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
         - service_unit.stat.exists
+        - not (svc_running and svc_healthy)
   rescue:
     - name: Show {{ item }} service status
       command: "systemctl status {{ kolla_service_unit_prefix }}{{ item }}{{ kolla_service_unit_suffix }}.service"
@@ -51,6 +66,22 @@
           Journal:
           {{ start_journal.stdout | default('') }}
 
+- name: Wait for {{ item }} to be running and healthy
+  become: true
+  kolla_container_facts:
+    action: get_containers
+    container_engine: "{{ kolla_container_engine }}"
+    name: "{{ item }}"
+  register: svc_health
+  retries: "{{ kolla_service_healthcheck_retries }}"
+  delay: "{{ kolla_service_healthcheck_delay }}"
+  until:
+    - svc_health.containers.get(item, {}).get('State', {}).get('Status') == 'running'
+    - (svc_health.containers.get(item, {}).get('State', {}).get('Health', {}).get('Status', 'healthy')) == 'healthy'
+  when:
+    - service_unit.stat.exists
+    - not (svc_running and svc_healthy)
+
 - name: Wait for neutron_ovs_cleanup to finish
   become: true
   kolla_container_facts:
@@ -65,3 +96,4 @@
     - item == 'neutron_ovs_cleanup'
     - service_unit.stat.exists
     - not ovs_cleanup_marker.stat.exists | default(false)
+    - not (svc_running and svc_healthy)

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -351,12 +351,18 @@ applied before continuing. The delays are controlled by the variables
 ``kolla_service_start_timeout`` (systemd ``TimeoutStartSec`` applied while
 waiting for dependency health; ``0`` disables the timeout) and
 ``kolla_service_no_healthcheck_wait`` (seconds to pause when no health
-check exists).
+check exists). During deploy and reconfigure the role also verifies that
+each service reaches the ``running`` and ``healthy`` states before moving
+on to the next. Containers that are already healthy are left running. The
+polling behaviour is controlled by ``kolla_service_healthcheck_retries``
+and ``kolla_service_healthcheck_delay``.
 
 .. code-block:: yaml
 
    kolla_service_start_timeout: 0
    kolla_service_no_healthcheck_wait: 30
+   kolla_service_healthcheck_retries: 60
+   kolla_service_healthcheck_delay: 2
 
 For example ``nova_compute`` waits for ``nova_ssh`` to become healthy,
 ``neutron_openvswitch_agent`` pauses for

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -35,7 +35,13 @@ The role reloads systemd after writing any drop-in files so that new
 dependencies are applied immediately. It also stops containers that were
 previously launched directly via Podman and restarts them under systemd.
 This ensures dependencies such as databases and messaging back ends are
-available before the corresponding API services are launched.
+available before the corresponding API services are launched. Each
+restart waits for the container to reach the ``running`` and ``healthy``
+states before the next service begins. Containers already in a healthy
+state are left running. If a service fails to become healthy within the
+configured timeout the playbook fails rather than waiting indefinitely.
+The timeout is governed by ``kolla_service_healthcheck_retries`` and
+``kolla_service_healthcheck_delay``.
 
 Handler auto-start
 ------------------

--- a/releasenotes/notes/service-start-order-health-wait-77e756adc2f8a528.yaml
+++ b/releasenotes/notes/service-start-order-health-wait-77e756adc2f8a528.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The ``service-start-order`` role now waits for each container to reach a
+    running and healthy state before moving on to dependent services. The
+    wait is bounded by ``kolla_service_healthcheck_retries`` and
+    ``kolla_service_healthcheck_delay`` and containers already in a healthy
+    state are not restarted. This prevents deployment hangs when a service
+    fails to become ready.


### PR DESCRIPTION
## Summary
- ensure service-start-order waits for containers to be running and healthy
- skip restarting containers already healthy and expose health check tuning variables
- document new health-based start order behaviour and timeouts

## Testing
- `tox -e linters` *(fails: 25 failure(s), 0 warning(s))*

------
https://chatgpt.com/codex/tasks/task_e_689b90c202cc83279116472752c8f33c