### PR TITLE
service-start-order: skip one-shot services

### DIFF
--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -36,3 +36,13 @@ kolla_service_healthcheck_delay: 2
 #####################
 # Marker file used to ensure neutron_ovs_cleanup runs only once per boot
 neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup/done"
+
+#####################
+# One-shot services
+#####################
+# Mapping of services which execute only once per host boot and should not be
+# restarted or waited on after completion. Each entry may define a marker file
+# indicating that the service has already run.
+kolla_service_one_shot:
+  neutron_ovs_cleanup:
+    marker: "{{ neutron_ovs_cleanup_marker_file }}"

--- a/ansible/roles/service-start-order/tasks/restart_service.yml
+++ b/ansible/roles/service-start-order/tasks/restart_service.yml
@@ -1,3 +1,10 @@
+- name: Check {{ svc }} marker
+  become: true
+  stat:
+    path: "{{ kolla_service_one_shot[svc].marker }}"
+  register: one_shot_marker
+  when: svc in kolla_service_one_shot
+
 - name: Stop Podman-started {{ svc }} container
   become: true
   command: "podman stop {{ svc }}"
@@ -6,6 +13,7 @@
   failed_when: podman_stop.rc not in [0, 125]
   when:
     - kolla_container_engine == 'podman'
+    - svc not in kolla_service_one_shot or not one_shot_marker.stat.exists | default(false)
 
 - name: Restart {{ svc }} service
   become: true
@@ -33,16 +41,33 @@
           {{ restart_status.stdout | default('') }}
           Journal:
           {{ restart_journal.stdout | default('') }}
-  always:
-    - name: Wait for {{ svc }} to be running and healthy
-      become: true
-      kolla_container_facts:
-        action: get_containers
-        container_engine: "{{ kolla_container_engine }}"
-        name: "{{ svc }}"
-      register: svc_health
-      retries: "{{ kolla_service_healthcheck_retries }}"
-      delay: "{{ kolla_service_healthcheck_delay }}"
-      until:
-        - svc_health.containers.get(svc, {}).get('State', {}).get('Status') == 'running'
-        - (svc_health.containers.get(svc, {}).get('State', {}).get('Health', {}).get('Status', 'healthy')) == 'healthy'
+  when: svc not in kolla_service_one_shot or not one_shot_marker.stat.exists | default(false)
+
+- name: Wait for {{ svc }} to be running and healthy
+  become: true
+  kolla_container_facts:
+    action: get_containers
+    container_engine: "{{ kolla_container_engine }}"
+    name: "{{ svc }}"
+  register: svc_health
+  retries: "{{ kolla_service_healthcheck_retries }}"
+  delay: "{{ kolla_service_healthcheck_delay }}"
+  until:
+    - svc_health.containers.get(svc, {}).get('State', {}).get('Status') == 'running'
+    - (svc_health.containers.get(svc, {}).get('State', {}).get('Health', {}).get('Status', 'healthy')) == 'healthy'
+  when:
+    - svc not in kolla_service_one_shot
+
+- name: Wait for {{ svc }} to finish
+  become: true
+  kolla_container_facts:
+    action: get_containers_state
+    container_engine: "{{ kolla_container_engine }}"
+    name: "{{ svc }}"
+  register: one_shot_state
+  retries: 12
+  delay: 5
+  until: one_shot_state.states[svc] != 'running'
+  when:
+    - svc in kolla_service_one_shot
+    - not one_shot_marker.stat.exists | default(false)

--- a/ansible/roles/service-start-order/tasks/start_service.yml
+++ b/ansible/roles/service-start-order/tasks/start_service.yml
@@ -1,9 +1,9 @@
-- name: Check neutron_ovs_cleanup marker
+- name: Check {{ item }} marker
   become: true
   stat:
-    path: "{{ neutron_ovs_cleanup_marker_file }}"
-  register: ovs_cleanup_marker
-  when: item == 'neutron_ovs_cleanup'
+    path: "{{ kolla_service_one_shot[item].marker }}"
+  register: one_shot_marker
+  when: item in kolla_service_one_shot
 
 - name: Check if {{ item }} unit file exists
   become: true
@@ -34,6 +34,7 @@
     - kolla_container_engine == 'podman'
     - service_unit.stat.exists
     - not (svc_running and svc_healthy)
+    - item not in kolla_service_one_shot or not one_shot_marker.stat.exists | default(false)
 
 - name: Start {{ item }} service
   become: true
@@ -45,7 +46,7 @@
         enabled: true
       register: start_result
       when:
-        - item != 'neutron_ovs_cleanup' or not ovs_cleanup_marker.stat.exists | default(false)
+        - item not in kolla_service_one_shot or not one_shot_marker.stat.exists | default(false)
         - service_unit.stat.exists
         - not (svc_running and svc_healthy)
   rescue:
@@ -81,19 +82,20 @@
   when:
     - service_unit.stat.exists
     - not (svc_running and svc_healthy)
+    - item not in kolla_service_one_shot
 
-- name: Wait for neutron_ovs_cleanup to finish
+- name: Wait for {{ item }} to finish
   become: true
   kolla_container_facts:
     action: get_containers_state
     container_engine: "{{ kolla_container_engine }}"
-    name: neutron_ovs_cleanup
-  register: cleanup_state
+    name: "{{ item }}"
+  register: one_shot_state
   retries: 12
   delay: 5
-  until: cleanup_state.states.neutron_ovs_cleanup != 'running'
+  until: one_shot_state.states[item] != 'running'
   when:
-    - item == 'neutron_ovs_cleanup'
+    - item in kolla_service_one_shot
     - service_unit.stat.exists
-    - not ovs_cleanup_marker.stat.exists | default(false)
+    - not one_shot_marker.stat.exists | default(false)
     - not (svc_running and svc_healthy)

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -374,8 +374,9 @@ The ``neutron_openvswitch_agent`` service waits for
 ``neutron_ovs_cleanup`` to complete before starting. The cleanup
 container executes only once per host boot; when the marker file
 ``/tmp/kolla/neutron_ovs_cleanup/done`` is present, the
-``service-start-order`` role skips starting the container. The marker path
-may be customised via the variable ``neutron_ovs_cleanup_marker_file``.
+``service-start-order`` role skips starting the container and does not
+wait for it to reach a running state. The marker path may be customised
+via the variable ``neutron_ovs_cleanup_marker_file``.
 
 Troubleshooting start ordering and health checks can be done with:
 

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -27,6 +27,8 @@ The container forms part of the compute service start sequence. The
 Podman is used these dependencies reference
 ``container-neutron_ovs_cleanup.service`` and
 ``container-neutron_openvswitch_agent.service`` units.
+Once the marker file is present the role skips restarting the cleanup
+container and does not wait for it to start.
 
 Manual execution
 ----------------


### PR DESCRIPTION
## Summary
- avoid restarting one-shot services like `neutron_ovs_cleanup`
- document one-shot service behaviour for service-start-order

## Testing
- `tox -e linters` *(fails: ansible-lint issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_689b9ab225588327bca2000f51b71401