### PR TITLE
Restart changed containers in service-start-order role

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -40,6 +40,20 @@
     start_order_restart_services: "{{ start_order_override_result.results | selectattr('changed') | map(attribute='item.1') | list }}"
   when: start_order_override_result is defined
 
+- name: Add changed containers to restart list
+  set_fact:
+    start_order_restart_services: >-
+      {{
+        (
+          start_order_restart_services | default([]) +
+          (
+            kolla_service_start_priority |
+            select('in', (kolla_changed_containers | default([]) | map('regex_replace', '-', '_') | list)) |
+            list
+          )
+        ) | unique
+      }}
+
 - name: Restart services if start order changed
   vars:
     restart_services: "{{ start_order_restart_services | default([]) }}"

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -353,9 +353,12 @@ waiting for dependency health; ``0`` disables the timeout) and
 ``kolla_service_no_healthcheck_wait`` (seconds to pause when no health
 check exists). During deploy and reconfigure the role also verifies that
 each service reaches the ``running`` and ``healthy`` states before moving
-on to the next. Containers that are already healthy are left running. The
-polling behaviour is controlled by ``kolla_service_healthcheck_retries``
-and ``kolla_service_healthcheck_delay``.
+on to the next. Containers that are already healthy are left running unless
+they were recorded in ``kolla_changed_containers`` during the playbook run.
+Services listed there, such as those newly created or recreated, are
+restarted to apply updated images or configuration. The polling behaviour
+is controlled by ``kolla_service_healthcheck_retries`` and
+``kolla_service_healthcheck_delay``.
 
 .. code-block:: yaml
 

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -59,7 +59,8 @@ consults this registry, stops any Podman-started containers once and then
 starts them under systemd using ``systemctl start
 container-<name>.service``. This transfers control to systemd so that
 start-order dependencies are honoured. Containers that were already
-managed by systemd are left running and are not restarted.
+managed by systemd are restarted only when listed in
+``kolla_changed_containers``; unchanged services are left running.
 
 Troubleshooting
 ---------------

--- a/molecule/service_start_order/playbook.yml
+++ b/molecule/service_start_order/playbook.yml
@@ -101,3 +101,4 @@
       vars:
         kolla_changed_containers:
           - c1
+          - c2

--- a/molecule/service_start_order/verify.yml
+++ b/molecule/service_start_order/verify.yml
@@ -53,4 +53,4 @@
       assert:
         that:
           - c1_after.stdout != start_before.c1
-          - c2_after.stdout == start_before.c2
+          - c2_after.stdout != start_before.c2


### PR DESCRIPTION
## Summary
- restart services whose containers were recreated during deploy
- document that kolla_changed_containers forces restarts and update Podman notes
- adjust service_start_order molecule scenario to cover changed container restarts

## Testing
- `python3 -m ansiblelint ansible/roles/service-start-order/tasks/deploy.yml`
- `python3 -m doc8 doc/source/admin/advanced-configuration.rst doc/source/admin/podman.rst`
- `python3 -m molecule test -s service_start_order` *(fails: Failed to find driver delegated)*

------
https://chatgpt.com/codex/tasks/task_e_689c7c1e26e88327b0832a6511333584