### PR TITLE
Add force option for Podman cleanup

### DIFF
--- a/ansible/roles/destroy/defaults/main.yml
+++ b/ansible/roles/destroy/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 destroy_include_images: "{{ enable_destroy_images }}"
 destroy_include_dev: "no"
+destroy_containers_running_vms_fatal: true

--- a/ansible/roles/destroy/tasks/cleanup_containers.yml
+++ b/ansible/roles/destroy/tasks/cleanup_containers.yml
@@ -1,3 +1,5 @@
 ---
 - name: Destroying all Kolla containers and volumes
-  script: ../tools/cleanup-containers "{{ kolla_container_engine }}"
+  script: >
+    ../tools/cleanup-containers "{{ kolla_container_engine }}"
+    {{ '--force' if not destroy_containers_running_vms_fatal | bool else '' }}

--- a/doc/source/user/operating-kolla.rst
+++ b/doc/source/user/operating-kolla.rst
@@ -293,6 +293,12 @@ remove all running Kolla containers from the selected container engine. It also
 removes the corresponding systemd units (``kolla-<name>-container.service`` for
 Docker and ``container-<name>.service`` for Podman) and the named volumes.
 
+By default the script will refuse to remove the ``nova_libvirt`` container if
+any QEMU processes are detected on the host. The safety check can be bypassed
+by passing ``--force`` to the script directly or by setting
+``destroy_containers_running_vms_fatal`` to ``false`` when running the
+``destroy`` playbook. Use this option with extreme care.
+
 ``tools/cleanup-host`` is used to remove remnants of network changes
 triggered on the host when the neutron-agents containers are launched.
 This can be useful when you want to do a new clean deployment, particularly one

--- a/tools/cleanup-containers
+++ b/tools/cleanup-containers
@@ -4,6 +4,21 @@
 engine="${1:-docker}"
 shift 1
 
+# parse optional arguments
+force="false"
+pattern=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force)
+            force="true"
+            ;;
+        *)
+            pattern="$1"
+            ;;
+    esac
+    shift 1
+done
+
 if ! [[ "$engine" =~ ^(docker|podman)$ ]]; then
     echo "Invalid container engine: ${engine}"
     exit 1
@@ -21,16 +36,18 @@ fi
 
 containers_running=$(sudo $engine ps --filter "label=kolla_version" --format "{{.Names}}")
 
-QEMU_PIDS=$(pgrep -l qemu | awk '!/qemu-ga/  && !/qemu-img/ {print $1}')
-if [[ "${containers_running}" =~ "nova_libvirt" ]] && [[ $QEMU_PIDS ]] && [[ $(ps --no-headers wwwup $QEMU_PIDS | grep --invert-match '\-xen\-domid 0') ]]; then
-    echo "Some qemu processes were detected."
-    echo "Container engine ($engine) will not be able to stop the nova_libvirt container with those running."
-    echo "Please clean them up before rerunning this script."
-    exit 1
-fi 
+if [ "$force" != "true" ]; then
+    QEMU_PIDS=$(pgrep -l qemu | awk '!/qemu-ga/  && !/qemu-img/ {print $1}')
+    if [[ "${containers_running}" =~ "nova_libvirt" ]] && [[ $QEMU_PIDS ]] && [[ $(ps --no-headers wwwup $QEMU_PIDS | grep --invert-match '\-xen\-domid 0') ]]; then
+        echo "Some qemu processes were detected."
+        echo "Container engine ($engine) will not be able to stop the nova_libvirt container with those running."
+        echo "Please clean them up before rerunning this script or use --force."
+        exit 1
+    fi
+fi
 
-if [ -n "$1" ]; then
-    containers_to_kill=$(sudo $engine ps --filter "label=kolla_version" --format "{{.Names}}" -a | grep -E "$1" | awk '{print $1}')
+if [ -n "$pattern" ]; then
+    containers_to_kill=$(sudo $engine ps --filter "label=kolla_version" --format "{{.Names}}" -a | grep -E "$pattern" | awk '{print $1 }')
     volumes_to_remove=$(sudo $engine inspect -f '{{range .Mounts}} {{printf "%s\n" .Name }}{{end}}' ${containers_to_kill} | \
         egrep -v '(^\s*$)' | sort | uniq)
 else
@@ -45,7 +62,8 @@ echo "Removing ovs bridge..."
 (sudo $engine exec -u root neutron_openvswitch_agent neutron-ovs-cleanup \
     --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini \
     --ovs_all_ports) > /dev/null
-(sudo $engine exec -it openvswitch_vswitchd bash -c 'for br in `ovs-vsctl list-br`;do ovs-vsctl --if-exists del-br $br;done') > /dev/null
+(sudo $engine exec -it openvswitch_vswitchd bash -c 'for br in `ovs-vsctl list-br`;do ovs-vsctl --if-exists del-br $br;done') >
+/dev/null
 fi
 
 echo "Stopping containers..."
@@ -75,3 +93,4 @@ sudo rm -f /etc/systemd/system/${unit_prefix}*${unit_suffix}.service
 sudo systemctl daemon-reload
 
 echo "All cleaned up!"
+


### PR DESCRIPTION
## Summary
- allow cleanup-containers to use `--force` to ignore running QEMU processes
- add `destroy_containers_running_vms_fatal` flag to destroy playbook
- document force cleanup behavior and podman support

## Testing
- `python3 -m tox -e linters` *(fails: ansible-lint reported violations and run interrupted)*
- `python3 -m pre_commit run --files tools/cleanup-containers ansible/roles/destroy/defaults/main.yml ansible/roles/destroy/tasks/cleanup_containers.yml doc/source/user/operating-kolla.rst` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_689c840195a08327a0da5299beb3c5b6