### PR TITLE
Ensure Podman-started containers restart under systemd

### DIFF
--- a/ansible/action_plugins/kolla_container.py
+++ b/ansible/action_plugins/kolla_container.py
@@ -1,0 +1,34 @@
+from ansible.plugins.action import ActionBase
+
+class ActionModule(ActionBase):
+    """Action plugin to wrap kolla_container module.
+
+    Records names of containers that are created, recreated or otherwise
+    changed during a playbook run. Changed container names are normalised to
+    use underscores and appended to the ``kolla_changed_containers`` fact so
+    that the ``service-start-order`` role can restart them under systemd.
+    """
+
+    TRANSFERS_FILES = False
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = {}
+        result = super(ActionModule, self).run(tmp, task_vars)
+        module_args = self._task.args.copy()
+        name = module_args.get('name')
+        action_result = self._execute_module(
+            module_name='kolla_container',
+            module_args=module_args,
+            task_vars=task_vars,
+            tmp=tmp,
+        )
+        result.update(action_result)
+
+        if action_result.get('changed') and name:
+            svc = name.replace('-', '_')
+            current = task_vars.get('kolla_changed_containers', []) or []
+            if svc not in current:
+                current.append(svc)
+            result.setdefault('ansible_facts', {})['kolla_changed_containers'] = current
+        return result

--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -42,17 +42,16 @@
 
 - name: Add changed containers to restart list
   set_fact:
-    start_order_restart_services: >-
-      {{
-        (
-          start_order_restart_services | default([]) +
-          (
-            kolla_service_start_priority |
-            select('in', (kolla_changed_containers | default([]) | map('regex_replace', '-', '_') | list)) |
-            list
-          )
-        ) | unique
-      }}
+    changed_restart_services: "{{ kolla_service_start_priority |
+      select('in', (kolla_changed_containers | default([]) |
+      map('regex_replace', '-', '_') | list)) | list }}"
+    start_order_restart_services: "{{ (start_order_restart_services |
+      default([]) + changed_restart_services) | unique }}"
+
+- name: Show restart candidates
+  debug:
+    msg: "Services queued for restart: {{ start_order_restart_services }}"
+  when: (start_order_restart_services | default([])) | length > 0
 
 - name: Restart services if start order changed
   vars:

--- a/ansible/roles/service-start-order/tasks/restart_service.yml
+++ b/ansible/roles/service-start-order/tasks/restart_service.yml
@@ -21,7 +21,7 @@
     - name: Restart {{ svc }} via systemd
       systemd:
         name: "{{ kolla_service_unit_prefix }}{{ svc }}{{ kolla_service_unit_suffix }}.service"
-        state: "{{ 'started' if svc in (kolla_changed_containers | default([])) else 'restarted' }}"
+        state: "{{ 'started' if svc in (kolla_changed_containers | default([]) | map('regex_replace', '-', '_') | list) else 'restarted' }}"
         daemon_reload: yes
       register: restart_result
   rescue:

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -355,10 +355,15 @@ check exists). During deploy and reconfigure the role also verifies that
 each service reaches the ``running`` and ``healthy`` states before moving
 on to the next. Containers that are already healthy are left running unless
 they were recorded in ``kolla_changed_containers`` during the playbook run.
-Services listed there, such as those newly created or recreated, are
+An action plugin for ``kolla_container`` automatically appends any
+changed container's name, with hyphens converted to underscores, to this
+fact. Services listed there, such as those newly created or recreated, are
 restarted to apply updated images or configuration. The polling behaviour
 is controlled by ``kolla_service_healthcheck_retries`` and
 ``kolla_service_healthcheck_delay``.
+Operators starting or modifying containers without ``kolla_container``
+must append the normalised service name to ``kolla_changed_containers``
+manually so that the restart ordering applies to them as well.
 
 .. code-block:: yaml
 

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -51,16 +51,20 @@ invoking ``podman start`` directly unless ``defer_start: true`` is
 specified. These direct starts avoid any reliance on systemd inside the
 container. When ``wait: true`` is also passed the handler first ensures
 the container is started and then waits for it to reach the running and
-healthy state before continuing. Containers started in this way are still
-recorded in ``kolla_changed_containers`` for the final ordered restart
-phase, which uses systemd when available to sequence service
-dependencies. During the restart phase the ``service-start-order`` role
-consults this registry, stops any Podman-started containers once and then
-starts them under systemd using ``systemctl start
-container-<name>.service``. This transfers control to systemd so that
-start-order dependencies are honoured. Containers that were already
-managed by systemd are restarted only when listed in
+healthy state before continuing. A dedicated action plugin for
+``kolla_container`` tracks any container whose definition changes and
+records the container's name, normalised with underscores, in the
+``kolla_changed_containers`` fact. The final ordered restart phase uses
+systemd when available to sequence service dependencies. During this
+phase the ``service-start-order`` role consults the registry, stops any
+Podman-started containers once and then starts them under systemd using
+``systemctl start container-<name>.service``. This transfers control to
+systemd so that start-order dependencies are honoured. Containers that
+were already managed by systemd are restarted only when listed in
 ``kolla_changed_containers``; unchanged services are left running.
+If a container is started or modified without using the
+``kolla_container`` module, its normalised name must be added manually to
+``kolla_changed_containers`` so that it is restarted during this phase.
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
## Summary
- track changed containers through a kolla_container action plugin
- normalize kolla_changed_containers and restart matching services
- document how container changes are recorded and restarted

## Testing
- `tox -e linters` *(fails: linters: exit -15 (360.58 seconds))*

------
https://chatgpt.com/codex/tasks/task_e_689c80f83a648327907a22bb2f35bf88