### PR TITLE
Fix openvswitch cleanup in tools/cleanup-containers

### DIFF
--- a/tools/cleanup-containers
+++ b/tools/cleanup-containers
@@ -62,8 +62,7 @@ echo "Removing ovs bridge..."
 (sudo $engine exec -u root neutron_openvswitch_agent neutron-ovs-cleanup \
     --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini \
     --ovs_all_ports) > /dev/null
-(sudo $engine exec -it openvswitch_vswitchd bash -c 'for br in `ovs-vsctl list-br`;do ovs-vsctl --if-exists del-br $br;done') >
-/dev/null
+(sudo $engine exec -it openvswitch_vswitchd bash -c 'for br in $(ovs-vsctl list-br); do ovs-vsctl --if-exists del-br $br; done') > /dev/null
 fi
 
 echo "Stopping containers..."


### PR DESCRIPTION
## Summary
- fix openvswitch cleanup quoting and redirect to ensure proper bridge removal

## Testing
- `tox -e linters` *(fails: unable to access https://opendev.org/openstack/ansible-collection-kolla/ (HTTP 503))*

------
https://chatgpt.com/codex/tasks/task_e_689c86f323208327a4d57d4fbd078623