### PR TITLE
service-start-order: compute restart list before merging

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -43,8 +43,10 @@
 - name: Add changed containers to restart list
   set_fact:
     changed_restart_services: "{{ kolla_service_start_priority |
-      select('in', (kolla_changed_containers | default([]) |
-      map('regex_replace', '-', '_') | list)) | list }}"
+      select('in', (kolla_changed_containers | default([]))) | list }}"
+
+- name: Merge restart candidates
+  set_fact:
     start_order_restart_services: "{{ (start_order_restart_services |
       default([]) + changed_restart_services) | unique }}"
 

--- a/ansible/roles/service-start-order/tasks/restart_service.yml
+++ b/ansible/roles/service-start-order/tasks/restart_service.yml
@@ -21,7 +21,7 @@
     - name: Restart {{ svc }} via systemd
       systemd:
         name: "{{ kolla_service_unit_prefix }}{{ svc }}{{ kolla_service_unit_suffix }}.service"
-        state: "{{ 'started' if svc in (kolla_changed_containers | default([]) | map('regex_replace', '-', '_') | list) else 'restarted' }}"
+        state: "{{ 'started' if svc in (kolla_changed_containers | default([])) else 'restarted' }}"
         daemon_reload: yes
       register: restart_result
   rescue:

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -358,9 +358,11 @@ they were recorded in ``kolla_changed_containers`` during the playbook run.
 An action plugin for ``kolla_container`` automatically appends any
 changed container's name, with hyphens converted to underscores, to this
 fact. Services listed there, such as those newly created or recreated, are
-restarted to apply updated images or configuration. The polling behaviour
-is controlled by ``kolla_service_healthcheck_retries`` and
-``kolla_service_healthcheck_delay``.
+restarted to apply updated images or configuration. The service-start-order
+role merges these names with any services whose start-order overrides have
+changed to build the restart list, so entries must use underscores to match
+service identifiers. The polling behaviour is controlled by
+``kolla_service_healthcheck_retries`` and ``kolla_service_healthcheck_delay``.
 Operators starting or modifying containers without ``kolla_container``
 must append the normalised service name to ``kolla_changed_containers``
 manually so that the restart ordering applies to them as well.

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -61,7 +61,10 @@ Podman-started containers once and then starts them under systemd using
 ``systemctl start container-<name>.service``. This transfers control to
 systemd so that start-order dependencies are honoured. Containers that
 were already managed by systemd are restarted only when listed in
-``kolla_changed_containers``; unchanged services are left running.
+``kolla_changed_containers``; unchanged services are left running. The
+role also merges this fact with any services whose start-order overrides
+changed to determine the final restart list, so entries must be
+underscore-normalised to match service names.
 If a container is started or modified without using the
 ``kolla_container`` module, its normalised name must be added manually to
 ``kolla_changed_containers`` so that it is restarted during this phase.


### PR DESCRIPTION
## Summary
- avoid undefined `changed_restart_services` by computing facts in sequence
- rely on underscore-normalised service names when determining restart state
- document how `kolla_changed_containers` feeds the ordered restart list

## Testing
- `python3 -m tox -e linters` *(fails: var-naming and jinja validation errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689c8aa8fca483278254a2ead3beec7c