### PR TITLE
Ensure changed containers restart consistently

### DIFF
--- a/ansible/action_plugins/kolla_container.py
+++ b/ansible/action_plugins/kolla_container.py
@@ -31,4 +31,7 @@ class ActionModule(ActionBase):
             if svc not in current:
                 current.append(svc)
             result.setdefault('ansible_facts', {})['kolla_changed_containers'] = current
+            # Mark fact cacheable so it persists across plays until
+            # service-start-order consumes it
+            result['ansible_facts_cacheable'] = True
         return result

--- a/ansible/roles/service-check-containers/handlers/main.yml
+++ b/ansible/roles/service-check-containers/handlers/main.yml
@@ -4,7 +4,10 @@
 
 - name: Start container immediately after (re)create
   become: true
-  command: "{{ kolla_container_engine }} start {{ container_name }}"
+  kolla_container:
+    action: start_container
+    common_options: "{{ docker_common_options }}"
+    name: "{{ container_name }}"
 
 - name: Ensure unit reflects new state
   become: true
@@ -26,10 +29,12 @@
 - name: Attempt runtime restart first
   listen: Restart container
   become: true
-  command: "{{ kolla_container_engine }} restart {{ container_name }}"
+  kolla_container:
+    action: restart_container
+    common_options: "{{ docker_common_options }}"
+    name: "{{ container_name }}"
   register: runtime_restart
-  failed_when: false
-  changed_when: runtime_restart.rc == 0
+  ignore_errors: true
   when: not container_needs_recreate | bool
 
 - name: Ensure unit enabled
@@ -40,7 +45,7 @@
     enabled: true
   when:
     - not container_needs_recreate | bool
-    - runtime_restart.rc != 0
+    - runtime_restart is failed
     - service.unit_file_exists | default(false) | bool
     - kolla_container_engine == 'docker' or kolla_podman_use_systemd | bool
 
@@ -52,7 +57,7 @@
     state: restarted
   when:
     - not container_needs_recreate | bool
-    - runtime_restart.rc != 0
+    - runtime_restart is failed
     - service.unit_file_exists | default(false) | bool
     - kolla_container_engine == 'docker' or kolla_podman_use_systemd | bool
 

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -357,15 +357,20 @@ on to the next. Containers that are already healthy are left running unless
 they were recorded in ``kolla_changed_containers`` during the playbook run.
 An action plugin for ``kolla_container`` automatically appends any
 changed container's name, with hyphens converted to underscores, to this
-fact. Services listed there, such as those newly created or recreated, are
-restarted to apply updated images or configuration. The service-start-order
-role merges these names with any services whose start-order overrides have
-changed to build the restart list, so entries must use underscores to match
-service identifiers. The polling behaviour is controlled by
+fact. ``kolla_changed_containers`` is cached per host and persists across
+roles until the ``service-start-order`` role consumes it. Services listed
+there, such as those newly created or recreated, are restarted to apply
+updated images or configuration. The service-start-order role merges these
+names with any services whose start-order overrides have changed to build
+the restart list, so entries must use underscores to match service
+identifiers. The polling behaviour is controlled by
 ``kolla_service_healthcheck_retries`` and ``kolla_service_healthcheck_delay``.
-Operators starting or modifying containers without ``kolla_container``
-must append the normalised service name to ``kolla_changed_containers``
-manually so that the restart ordering applies to them as well.
+All container creation or start tasks in Kolla Ansible roles must invoke
+the ``kolla_container`` module so that the action plugin can update the
+fact. Operators starting or modifying containers without
+``kolla_container`` must append the normalised service name to
+``kolla_changed_containers`` manually so that the restart ordering applies
+to them as well.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Summary
- mark kolla_container action plugin facts cacheable so container changes persist until restart
- use kolla_container action plugin when handlers start or restart containers
- document requirement to invoke kolla_container for container creation/start and clarify fact caching

## Testing
- `tox -e linters` *(fails: ansible-lint j2lint/var-naming violations)*
- `tox -e docs` *(fails: missing pcre.h during python-pcre build)*

------
https://chatgpt.com/codex/tasks/task_e_689c8f3ced9c832787ad9a484da032b2