### PR TITLE
Ensure neutron OVS cleanup runs before agent with reboot delay

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -34,6 +34,11 @@ neutron_services:
     privileged: True
     environment:
       KOLLA_LEGACY_IPTABLES: "{{ neutron_legacy_iptables | bool | lower }}"
+    podman_systemd_dependencies:
+      - "After=container-openvswitch_vswitchd.service"
+      - "Requires=container-openvswitch_vswitchd.service"
+      - "After=container-neutron_ovs_cleanup.service"
+      - "Requires=container-neutron_ovs_cleanup.service"
     host_in_groups: >-
       {{
       (inventory_hostname in groups['compute']
@@ -992,4 +997,4 @@ neutron_copy_certs: "{{ kolla_copy_ca_into_containers | bool or neutron_enable_t
 #####################
 # OVS cleanup
 #####################
-neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup/done"
+neutron_ovs_cleanup_marker_file: "/run/kolla/neutron_ovs_cleanup/done"

--- a/ansible/roles/neutron/tasks/deploy.yml
+++ b/ansible/roles/neutron/tasks/deploy.yml
@@ -12,6 +12,10 @@
 
 - import_tasks: ovs-cleanup.yml
 
+- import_tasks: podman-systemd.yml
+  when:
+    - kolla_container_engine == 'podman'
+
 - import_tasks: check-containers.yml
 
 - include_tasks: config-neutron-fake.yml

--- a/ansible/roles/neutron/tasks/podman-systemd.yml
+++ b/ansible/roles/neutron/tasks/podman-systemd.yml
@@ -1,0 +1,12 @@
+---
+# Generate systemd unit files for Neutron containers when using Podman
+- name: Generate Podman systemd units for Neutron
+  include_role:
+    name: common
+    tasks_from: podman_systemd
+  vars:
+    service: "{{ item.value }}"
+  loop: "{{ neutron_services | select_services_enabled_and_mapped_to_host | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+

--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -30,12 +30,16 @@ kolla_service_no_healthcheck_wait: 30
 # Attempts and delay for verifying container health after restart/start
 kolla_service_healthcheck_retries: 60
 kolla_service_healthcheck_delay: 2
+# Additional delay after dependency is healthy during host boot
+kolla_post_healthy_delay: 30
+# Marker file whose presence disables the post-healthy delay
+kolla_post_healthy_delay_marker_file: "/run/kolla/ansible-start-order"
 
 #####################
 # OVS cleanup
 #####################
 # Marker file used to ensure neutron_ovs_cleanup runs only once per boot
-neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup/done"
+neutron_ovs_cleanup_marker_file: "/run/kolla/neutron_ovs_cleanup/done"
 
 #####################
 # One-shot services

--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -1,4 +1,18 @@
 ---
+- name: Ensure post-healthy delay marker directory exists
+  become: true
+  file:
+    path: "{{ kolla_post_healthy_delay_marker_file | dirname }}"
+    state: directory
+    mode: "0755"
+
+- name: Ensure post-healthy delay marker exists
+  become: true
+  file:
+    path: "{{ kolla_post_healthy_delay_marker_file }}"
+    state: touch
+    mode: "0644"
+
 - name: Detect services with systemd units
   become: true
   stat:

--- a/ansible/roles/service-start-order/templates/start-order.conf.j2
+++ b/ansible/roles/service-start-order/templates/start-order.conf.j2
@@ -24,4 +24,8 @@ ExecStartPre=/bin/sh -c '\
   else \
     sleep {{ kolla_service_no_healthcheck_wait }}; \
   fi; \
+  delay=${KOLLA_POST_HEALTHY_DELAY:-{{ kolla_post_healthy_delay }}}; \
+  if [ ! -f {{ kolla_post_healthy_delay_marker_file }} ] && [ "$delay" -gt 0 ]; then \
+    sleep $delay; \
+  fi; \
   exit 0'

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -378,6 +378,7 @@ to them as well.
    kolla_service_no_healthcheck_wait: 30
    kolla_service_healthcheck_retries: 60
    kolla_service_healthcheck_delay: 2
+   kolla_post_healthy_delay: 30
 
 For example ``nova_compute`` waits for ``nova_ssh`` to become healthy,
 ``neutron_openvswitch_agent`` pauses for
@@ -388,10 +389,13 @@ overridden in ``/etc/kolla/globals.yml``.
 The ``neutron_openvswitch_agent`` service waits for
 ``neutron_ovs_cleanup`` to complete before starting. The cleanup
 container executes only once per host boot; when the marker file
-``/tmp/kolla/neutron_ovs_cleanup/done`` is present, the
+``/run/kolla/neutron_ovs_cleanup/done`` is present, the
 ``service-start-order`` role skips starting the container and does not
 wait for it to reach a running state. The marker path may be customised
-via the variable ``neutron_ovs_cleanup_marker_file``.
+via the variable ``neutron_ovs_cleanup_marker_file``. After a dependency
+reports healthy during host boot, services pause for
+``kolla_post_healthy_delay`` seconds (default 30) before starting the next
+unit. This delay does not apply during initial deployment runs.
 
 Troubleshooting start ordering and health checks can be done with:
 

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -84,5 +84,5 @@ One-shot cleanup containers
 
 Cleanup containers like ``neutron_ovs_cleanup`` are started as normal
 services.  They run at boot and create a marker file
-``/tmp/kolla/neutron_ovs_cleanup/done`` so subsequent starts skip the
+``/run/kolla/neutron_ovs_cleanup/done`` so subsequent starts skip the
 container until the host reboots.

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -13,7 +13,7 @@ Operation
 
 During deployment the container runs once per host boot. After completing the
 cleanup it exits and remains stopped for manual reuse. The container itself
-creates a marker file ``/tmp/kolla/neutron_ovs_cleanup/done`` to prevent
+creates a marker file ``/run/kolla/neutron_ovs_cleanup/done`` to prevent
 further automatic executions until the host is rebooted. If the container
 configuration changes, the playbook recreates the container so the updated
 settings will be applied on the next run, but the container does not execute
@@ -49,4 +49,4 @@ To force automatic execution again remove the marker file:
 
 .. code-block:: console
 
-   sudo rm /tmp/kolla/neutron_ovs_cleanup/done
+   sudo rm /run/kolla/neutron_ovs_cleanup/done

--- a/releasenotes/notes/post-healthy-delay-neutron-ovs-cleanup.yaml
+++ b/releasenotes/notes/post-healthy-delay-neutron-ovs-cleanup.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adds a configurable ``KOLLA_POST_HEALTHY_DELAY`` (default 30 seconds)
+    applied only during host boot after dependencies become healthy.
+    This ensures systemd honours container start ordering. The
+    ``neutron_ovs_cleanup`` service now uses a marker in
+    ``/run/kolla/neutron_ovs_cleanup/done`` so it runs exactly once per
+    reboot before ``neutron_openvswitch_agent`` starts.


### PR DESCRIPTION
## Summary
- ensure `neutron_ovs_cleanup` marker lives in `/run/kolla` so the container executes once per boot
- enforce OVS agent ordering and add reboot-only `KOLLA_POST_HEALTHY_DELAY`
- generate podman systemd units for neutron services to honour dependencies

## Testing
- `python3 -m tox -e linters` *(fails: yaml formatting and jinja template errors)*


------
https://chatgpt.com/codex/tasks/task_e_689c9ba311a08327b61656ce6947ff54