### PR TITLE
Recreate neutron OVS cleanup script at startup

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -40,7 +40,7 @@
     action: "compare_container"
     common_options: "{{ docker_common_options }}"
     command: >-
-      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
+      bash -c "sudo -E kolla_set_configs && mkdir -p /tmp/kolla && cp -a $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
@@ -63,7 +63,7 @@
     action: "recreate_container"
     common_options: "{{ docker_common_options }}"
     command: >-
-      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
+      bash -c "sudo -E kolla_set_configs && mkdir -p /tmp/kolla && cp -a $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
@@ -88,7 +88,7 @@
     common_options: "{{ docker_common_options }}"
     detach: False
     command: >-
-      bash -c 'sudo -E kolla_set_configs && neutron-ovs-cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}'
+      bash -c "sudo -E kolla_set_configs && mkdir -p /tmp/kolla && cp -a $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -85,4 +85,6 @@ One-shot cleanup containers
 Cleanup containers like ``neutron_ovs_cleanup`` are started as normal
 services.  They run at boot and create a marker file
 ``/tmp/kolla/neutron_ovs_cleanup/done`` so subsequent starts skip the
-container until the host reboots.
+container until the host reboots. Because ``/tmp`` is recreated on each
+boot, the container copies its cleanup script to ``/tmp/kolla`` every time
+it starts.

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -17,7 +17,9 @@ creates a marker file ``/tmp/kolla/neutron_ovs_cleanup/done`` to prevent
 further automatic executions until the host is rebooted. If the container
 configuration changes, the playbook recreates the container so the updated
 settings will be applied on the next run, but the container does not execute
-again while the marker file exists.
+again while the marker file exists. Because ``/tmp`` is an ephemeral
+filesystem, the container recreates ``/tmp/kolla`` and copies the cleanup
+script to ``/tmp/kolla/neutron_ovs_cleanup`` each time it starts.
 The marker path can be changed by overriding the variable
 ``neutron_ovs_cleanup_marker_file``.
 


### PR DESCRIPTION
## Summary
- ensure neutron_ovs_cleanup container copies its script to `/tmp/kolla` on every start
- document that the cleanup script is recreated in `/tmp` at runtime

## Testing
- `python3 -m tox -e linters` *(fails: listing 25 violations)*

------
https://chatgpt.com/codex/tasks/task_e_689ca1af2c2483278b06999a495f73d2