### PR TITLE
Fix neutron OVS cleanup marker path to avoid script conflict

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -992,4 +992,8 @@ neutron_copy_certs: "{{ kolla_copy_ca_into_containers | bool or neutron_enable_t
 #####################
 # OVS cleanup
 #####################
-neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup/done"
+# Marker file used by the ``neutron-ovs-cleanup`` container to ensure it
+# only executes once per host boot.  A dedicated directory avoids
+# colliding with the temporary location where the cleanup script is copied
+# inside the container.
+neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup_marker/done"

--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -34,8 +34,10 @@ kolla_service_healthcheck_delay: 2
 #####################
 # OVS cleanup
 #####################
-# Marker file used to ensure neutron_ovs_cleanup runs only once per boot
-neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup/done"
+# Marker file used to ensure neutron_ovs_cleanup runs only once per boot.
+# A dedicated directory prevents conflicts with the cleanup script which is
+# copied to ``/tmp/kolla/neutron_ovs_cleanup`` inside the container.
+neutron_ovs_cleanup_marker_file: "/tmp/kolla/neutron_ovs_cleanup_marker/done"
 
 #####################
 # One-shot services

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -388,7 +388,7 @@ overridden in ``/etc/kolla/globals.yml``.
 The ``neutron_openvswitch_agent`` service waits for
 ``neutron_ovs_cleanup`` to complete before starting. The cleanup
 container executes only once per host boot; when the marker file
-``/tmp/kolla/neutron_ovs_cleanup/done`` is present, the
+``/tmp/kolla/neutron_ovs_cleanup_marker/done`` is present, the
 ``service-start-order`` role skips starting the container and does not
 wait for it to reach a running state. The marker path may be customised
 via the variable ``neutron_ovs_cleanup_marker_file``.

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -84,7 +84,7 @@ One-shot cleanup containers
 
 Cleanup containers like ``neutron_ovs_cleanup`` are started as normal
 services.  They run at boot and create a marker file
-``/tmp/kolla/neutron_ovs_cleanup/done`` so subsequent starts skip the
+``/tmp/kolla/neutron_ovs_cleanup_marker/done`` so subsequent starts skip the
 container until the host reboots. Because ``/tmp`` is recreated on each
 boot, the container copies its cleanup script to ``/tmp/kolla`` every time
 it starts.

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -13,7 +13,7 @@ Operation
 
 During deployment the container runs once per host boot. After completing the
 cleanup it exits and remains stopped for manual reuse. The container itself
-creates a marker file ``/tmp/kolla/neutron_ovs_cleanup/done`` to prevent
+creates a marker file ``/tmp/kolla/neutron_ovs_cleanup_marker/done`` to prevent
 further automatic executions until the host is rebooted. If the container
 configuration changes, the playbook recreates the container so the updated
 settings will be applied on the next run, but the container does not execute
@@ -51,4 +51,4 @@ To force automatic execution again remove the marker file:
 
 .. code-block:: console
 
-   sudo rm /tmp/kolla/neutron_ovs_cleanup/done
+   sudo rm /tmp/kolla/neutron_ovs_cleanup_marker/done

--- a/releasenotes/notes/fix-ovs-cleanup-marker-path-4d2c3ef2c2dcd202.yaml
+++ b/releasenotes/notes/fix-ovs-cleanup-marker-path-4d2c3ef2c2dcd202.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a regression where the ``neutron-ovs-cleanup`` marker directory
+    shared the same path as the cleanup script, causing the container to
+    exit with ``Is a directory``.  The marker file now defaults to
+    ``/tmp/kolla/neutron_ovs_cleanup_marker/done``, restoring execution of
+    the cleanup script.


### PR DESCRIPTION
## Summary
- store neutron-ovs-cleanup marker in a dedicated directory to avoid collision with the script location
- document new marker path and add release note

## Testing
- `ansible-lint -p ansible/roles/neutron/defaults/main.yml ansible/roles/service-start-order/defaults/main.yml`
- `doc8 doc/source/admin/advanced-configuration.rst doc/source/admin/podman.rst doc/source/reference/networking/ovs-cleanup.rst`
- `podman run --rm --privileged alpine sh -c "mkdir -p /tmp/kolla/neutron_ovs_cleanup_marker && cp -a /bin/true /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup && touch /tmp/kolla/neutron_ovs_cleanup_marker/done"` *(fails: netavark setns: Operation not permitted)*


------
https://chatgpt.com/codex/tasks/task_e_689cabc1f9f48327b8cfc430032940e7