### PR TITLE
neutron: run ovs cleanup without sudo

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -47,7 +47,7 @@
     action: "compare_container"
     common_options: "{{ docker_common_options }}"
     command: >-
-      bash -c "sudo -E kolla_set_configs && sudo install -o neutron -g neutron -m 0755 -d /tmp/kolla && sudo install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
+      bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
@@ -70,7 +70,7 @@
     action: "recreate_container"
     common_options: "{{ docker_common_options }}"
     command: >-
-      bash -c "sudo -E kolla_set_configs && sudo install -o neutron -g neutron -m 0755 -d /tmp/kolla && sudo install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
+      bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
@@ -95,7 +95,7 @@
     common_options: "{{ docker_common_options }}"
     detach: False
     command: >-
-      bash -c "sudo -E kolla_set_configs && sudo install -o neutron -g neutron -m 0755 -d /tmp/kolla && sudo install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
+      bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     privileged: "{{ service.privileged | default(False) }}"
     labels:

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -24,6 +24,9 @@ each time it starts so that the non-root ``neutron`` user can write to it.
 The marker path can be changed by overriding the variable
 ``neutron_ovs_cleanup_marker_file``.
 
+The container executes the cleanup script as root directly, avoiding
+any reliance on ``sudo`` or interactive prompts.
+
 The container forms part of the compute service start sequence. The
 ``service-start-order`` role configures systemd dependencies so that the
 ``neutron_openvswitch_agent`` unit waits for the cleanup to complete. When

--- a/releasenotes/notes/ovs-cleanup-sudo-tty-fix-83f9f98528911be1.yaml
+++ b/releasenotes/notes/ovs-cleanup-sudo-tty-fix-83f9f98528911be1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue where the ``neutron-ovs-cleanup`` container failed when
+    ``sudo`` required a TTY. The cleanup script now runs directly as root
+    without invoking ``sudo``.


### PR DESCRIPTION
## Summary
- run neutron-ovs-cleanup script without using sudo
- document that the cleanup runs directly as root

## Testing
- `.tox/linters/bin/ansible-lint ansible/roles/neutron/tasks/ovs-cleanup.yml`
- `.tox/linters/bin/doc8 doc/source/reference/networking/ovs-cleanup.rst`
- `.tox/linters/bin/yamllint releasenotes/notes/ovs-cleanup-sudo-tty-fix-83f9f98528911be1.yaml`

------
https://chatgpt.com/codex/tasks/task_e_689dcc48deac83279b4a63d6625a311a