### PR TITLE
Fix neutron-ovs-cleanup config permissions

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -20,7 +20,7 @@
     state: "directory"
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
-    mode: "0770"
+    mode: "0755"
   when:
     - neutron_services['neutron-openvswitch-agent']['enabled'] | bool
     - inventory_hostname in groups['neutron-openvswitch-agent']
@@ -678,7 +678,7 @@
     remote_src: true
     src: "{{ item }}"
     dest: "{{ cleanup_dir }}/{{ item | basename }}"
-    mode: "0660"
+    mode: "{{ '0644' if item | basename == 'config.json' else '0660' }}"
   loop:
     - "{{ ovs_agent_dir }}/config.json"
     - "{{ ovs_agent_dir }}/neutron.conf"

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -27,6 +27,12 @@ The marker path can be changed by overriding the variable
 The container executes the cleanup script as root directly, avoiding
 any reliance on ``sudo`` or interactive prompts.
 
+The container reads its configuration from
+``/etc/kolla/neutron-ovs-cleanup/config.json`` before the cleanup
+script runs.  To ensure this is always accessible, Kolla Ansible creates
+the configuration directory with ``0755`` permissions and installs the
+``config.json`` file with mode ``0644``.
+
 The container forms part of the compute service start sequence. The
 ``service-start-order`` role configures systemd dependencies so that the
 ``neutron_openvswitch_agent`` unit waits for the cleanup to complete. When

--- a/releasenotes/notes/neutron-ovs-cleanup-config-perms-025c510ee937e896.yaml
+++ b/releasenotes/notes/neutron-ovs-cleanup-config-perms-025c510ee937e896.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a regression that caused the ``neutron-ovs-cleanup`` container to
+    fail with a permission error when reading its configuration. The
+    configuration directory now uses ``0755`` permissions and ``config.json``
+    is installed with mode ``0644``.


### PR DESCRIPTION
## Summary
- ensure neutron-ovs-cleanup config directory and config.json are readable
- document neutron-ovs-cleanup configuration permissions

## Testing
- `tox -e linters` *(fails: 25 failure(s))*
- `tox -e docs`


------
https://chatgpt.com/codex/tasks/task_e_689dd259b050832794909fef34bb18c3