### PR TITLE
fix: run neutron ovs cleanup as root

### DIFF
--- a/ansible/library/kolla_container.py
+++ b/ansible/library/kolla_container.py
@@ -110,6 +110,11 @@ options:
       - The environment to set for the container
     required: False
     type: dict
+  user:
+    description:
+      - User to run the container as
+    required: False
+    type: str
   image:
     description:
       - Name of the docker image
@@ -314,6 +319,7 @@ def generate_module():
         labels=dict(required=False, type='dict', default=dict()),
         name=dict(required=False, type='str'),
         environment=dict(required=False, type='dict'),
+        user=dict(required=False, type='str'),
         healthcheck=dict(required=False, type='dict'),
         start=dict(required=False, type='bool', default=True),
         defer_start=dict(required=False, type='bool', default=False),

--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -492,6 +492,10 @@ class ContainerWorker(ABC):
             self._debug("command differs")
             self._diff_keys.append("command")
             differs = True
+        if self.compare_user(container_info):
+            self._debug("user differs")
+            self._diff_keys.append("user")
+            differs = True
         if self.compare_healthcheck(container_info):
             self._debug("healthcheck differs")
             self._diff_keys.append("healthcheck")
@@ -851,6 +855,14 @@ class ContainerWorker(ABC):
                 if " ".join(new_cmd) == " ".join(current_cmd):
                     return False
                 return True
+
+    def compare_user(self, container_info):
+        new_user = self.params.get("user")
+        current_user = container_info.get("Config", {}).get("User")
+        if not current_user:
+            current_user = None
+        if new_user != current_user:
+            return True
 
     def compare_healthcheck(self, container_info):
         new_healthcheck = self.parse_healthcheck(self.params.get("healthcheck"))

--- a/ansible/module_utils/kolla_docker_worker.py
+++ b/ansible/module_utils/kolla_docker_worker.py
@@ -314,6 +314,9 @@ class DockerWorker(ContainerWorker):
             "tty": self.params.get("tty"),
         }
 
+        if self.params.get("user") is not None:
+            options["user"] = self.params.get("user")
+
         healthcheck = self.parse_healthcheck(self.params.get("healthcheck"))
         if healthcheck:
             options.update(healthcheck)

--- a/ansible/module_utils/kolla_podman_worker.py
+++ b/ansible/module_utils/kolla_podman_worker.py
@@ -57,6 +57,7 @@ CONTAINER_PARAMS = [
     "detach",  # bool
     "entrypoint",  # string
     "environment",  # dict docker - environment - dictionary
+    "user",  # string
     "healthcheck",  # same schema as docker -- healthcheck
     "image",  # string
     "ipc_mode",  # string only option is host

--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -49,6 +49,7 @@
     command: >-
       bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
+    user: "root"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""
@@ -72,6 +73,7 @@
     command: >-
       bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
+    user: "root"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""
@@ -97,6 +99,7 @@
     command: >-
       bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
+    user: "root"
     privileged: "{{ service.privileged | default(False) }}"
     labels:
       OVSCLEANUP: ""

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -25,7 +25,9 @@ The marker path can be changed by overriding the variable
 ``neutron_ovs_cleanup_marker_file``.
 
 The container executes the cleanup script as root directly, avoiding
-any reliance on ``sudo`` or interactive prompts.
+any reliance on ``sudo`` or interactive prompts.  It now explicitly
+runs as the root user so that ``kolla_set_configs`` can create and
+populate ``/etc/kolla/defaults`` before the cleanup script runs.
 
 The container reads its configuration from
 ``/etc/kolla/neutron-ovs-cleanup/config.json`` before the cleanup

--- a/releasenotes/notes/neutron-ovs-cleanup-defaults-dir-fix-7c1e72605e7a8d3d.yaml
+++ b/releasenotes/notes/neutron-ovs-cleanup-defaults-dir-fix-7c1e72605e7a8d3d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue where the ``neutron-ovs-cleanup`` container failed with a
+    permission error while creating ``/etc/kolla/defaults``. The container now
+    runs ``kolla_set_configs`` as the root user so the defaults directory
+    can be created before the cleanup script executes.


### PR DESCRIPTION
## Summary
- allow kolla_container to specify container user
- run neutron-ovs-cleanup container as root so kolla_set_configs can create /etc/kolla/defaults
- document behavior and add release note

## Testing
- `python3 -m tox -e linters` *(fails: var-naming, yaml formatting, ansible-lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dd7c0cef0832792869e3e1558aed3