### PR TITLE
neutron: ensure ovs-cleanup log directory

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -16,6 +16,15 @@
     neutron_uid: "{{ neutron_uid_result.stdout }}"
     neutron_gid: "{{ neutron_gid_result.stdout }}"
 
+- name: Ensure neutron log directory exists
+  become: true
+  file:
+    path: "/var/log/kolla/neutron"
+    state: directory
+    owner: "{{ neutron_uid }}"
+    group: "{{ neutron_gid }}"
+    mode: "0755"
+
 - name: Ensure /tmp/kolla exists with correct permissions
   become: true
   file:

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -35,6 +35,11 @@ script runs.  To ensure this is always accessible, Kolla Ansible creates
 the configuration directory with ``0755`` permissions and installs the
 ``config.json`` file with mode ``0644``.
 
+The cleanup script writes its log file to
+``/var/log/kolla/neutron/neutron_ovs_cleanup.log``. Kolla Ansible
+creates the ``/var/log/kolla/neutron`` directory with the appropriate
+ownership before the container runs so that logging succeeds.
+
 The container forms part of the compute service start sequence. The
 ``service-start-order`` role configures systemd dependencies so that the
 ``neutron_openvswitch_agent`` unit waits for the cleanup to complete. When


### PR DESCRIPTION
## Summary
- ensure neutron-ovs-cleanup log directory exists prior to container run
- document log file location for neutron-ovs-cleanup

## Testing
- `python3 -m tox -e linters` *(fails: yaml and var-naming warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689ddd1c1220832798eeca05d90e469b