### PR TITLE
service-start-order: apply post-healthy delay for podman healthchecks

### DIFF
--- a/ansible/roles/service-start-order/templates/start-order.conf.j2
+++ b/ansible/roles/service-start-order/templates/start-order.conf.j2
@@ -8,14 +8,18 @@ TimeoutStartSec={{ kolla_service_start_timeout }}
 ExecStartPre=/bin/sh -c '\
   until systemctl is-active --quiet {{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}.service; do sleep 1; done; \
   if [ "{{ kolla_container_engine }}" = "podman" ]; then \
-    {{ kolla_container_engine }} healthcheck run {{ item.0 }} >/dev/null 2>&1; \
-    rc=$?; \
+    {{ kolla_container_engine }} healthcheck run {{ item.0 }} >/dev/null 2>&1; rc=$?; \
     if [ $rc -eq 125 ]; then \
+      # no healthcheck \
       sleep {{ kolla_service_no_healthcheck_wait }}; \
+{% if post_delay|int > 0 %}      sleep {{ post_delay }}; \{% endif %}
     elif [ $rc -ne 0 ]; then \
       until {{ kolla_container_engine }} healthcheck run {{ item.0 }} >/dev/null 2>&1; do sleep 1; done; \
+{% if post_delay|int > 0 %}      sleep {{ post_delay }}; \{% endif %}
+    else \
+      # already healthy \
+{% if post_delay|int > 0 %}      sleep {{ post_delay }}; \{% else %}      :; \{% endif %}
     fi; \
-{% if post_delay|int > 0 %}    sleep {{ post_delay }}; \{% endif %}
   elif [ "{{ kolla_container_engine }}" = "docker" ]; then \
     has_hc=$({{ kolla_container_engine }} inspect --format={{"{{"}}json .Config.Healthcheck{{"}}"}} {{ item.0 }}); \
     if [ "$has_hc" = "null" ] || [ -z "$has_hc" ]; then \


### PR DESCRIPTION
## Summary
- ensure podman start-order drop-ins always honour post-healthy delay

## Testing
- `tox -e linters` *(fails: var-naming, yaml and jinja violations)*

------
https://chatgpt.com/codex/tasks/task_e_689df776c764832785a7e634925c43e8