### PR TITLE
neutron: bind mount /tmp for ovs cleanup

### DIFF
--- a/ansible/roles/neutron/tasks/ovs-cleanup.yml
+++ b/ansible/roles/neutron/tasks/ovs-cleanup.yml
@@ -56,7 +56,7 @@
     action: "compare_container"
     common_options: "{{ docker_common_options }}"
     command: >-
-      bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
+      bash -c "kolla_set_configs && install -o neutron -g neutron -m 1777 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     user: "root"
     privileged: "{{ service.privileged | default(False) }}"
@@ -66,7 +66,7 @@
     restart_policy: no
     state: exited
     remove_on_exit: false
-    volumes: "{{ ([ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', neutron_ovs_cleanup_marker_file | dirname ~ ':' ~ neutron_ovs_cleanup_marker_file | dirname ] + (service.volumes[1:] | list)) | reject('equalto', '') | list }}"
+    volumes: "{{ ([ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', '/tmp:/tmp' ] + (service.volumes[1:] | list)) | reject('equalto', '') | list }}"
   register: ovs_cleanup_compare
   when:
     - service | service_enabled_and_mapped_to_host
@@ -80,7 +80,7 @@
     action: "recreate_container"
     common_options: "{{ docker_common_options }}"
     command: >-
-      bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
+      bash -c "kolla_set_configs && install -o neutron -g neutron -m 1777 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     user: "root"
     privileged: "{{ service.privileged | default(False) }}"
@@ -90,7 +90,7 @@
     restart_policy: no
     state: exited
     remove_on_exit: false
-    volumes: "{{ ([ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', neutron_ovs_cleanup_marker_file | dirname ~ ':' ~ neutron_ovs_cleanup_marker_file | dirname ] + (service.volumes[1:] | list)) | reject('equalto', '') | list }}"
+    volumes: "{{ ([ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', '/tmp:/tmp' ] + (service.volumes[1:] | list)) | reject('equalto', '') | list }}"
   when:
     - service | service_enabled_and_mapped_to_host
     - ovs_cleanup_marker.stat.exists
@@ -106,7 +106,7 @@
     common_options: "{{ docker_common_options }}"
     detach: False
     command: >-
-      bash -c "kolla_set_configs && install -o neutron -g neutron -m 0755 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
+      bash -c "kolla_set_configs && install -o neutron -g neutron -m 1777 -d /tmp/kolla && install -o neutron -g neutron -m 0755 $(command -v neutron-ovs-cleanup) /tmp/kolla/neutron_ovs_cleanup && /tmp/kolla/neutron_ovs_cleanup --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugins/ml2/openvswitch_agent.ini && touch {{ neutron_ovs_cleanup_marker_file }}"
     image: "{{ neutron_openvswitch_agent_image_full }}"
     user: "root"
     privileged: "{{ service.privileged | default(False) }}"
@@ -115,7 +115,7 @@
     name: "neutron_ovs_cleanup"
     restart_policy: no
     remove_on_exit: false
-    volumes: "{{ ([ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', neutron_ovs_cleanup_marker_file | dirname ~ ':' ~ neutron_ovs_cleanup_marker_file | dirname ] + (service.volumes[1:] | list)) | reject('equalto', '') | list }}"
+    volumes: "{{ ([ node_config_directory ~ '/neutron-ovs-cleanup/:' ~ container_config_directory ~ '/:ro', '/tmp:/tmp' ] + (service.volumes[1:] | list)) | reject('equalto', '') | list }}"
   when:
     - service | service_enabled_and_mapped_to_host
     - not ovs_cleanup_marker.stat.exists

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -92,7 +92,7 @@ One-shot cleanup containers
 Cleanup containers like ``neutron_ovs_cleanup`` are started as normal
 services.  They run at boot and create a marker file
 ``/tmp/kolla/neutron_ovs_cleanup_marker/done`` so subsequent starts skip the
-container until the host reboots. Because ``/tmp`` is recreated on each
-boot, the container creates ``/tmp/kolla`` with ``1777`` permissions and
-copies its cleanup script to ``/tmp/kolla/neutron_ovs_cleanup`` every time
-it starts.
+container until the host reboots. The container bind mounts the host
+``/tmp`` directory; because ``/tmp`` is recreated on each boot, the container
+creates ``/tmp/kolla`` with ``1777`` permissions and copies its cleanup
+script to ``/tmp/kolla/neutron_ovs_cleanup`` every time it starts.

--- a/doc/source/reference/networking/ovs-cleanup.rst
+++ b/doc/source/reference/networking/ovs-cleanup.rst
@@ -17,12 +17,13 @@ creates a marker file ``/tmp/kolla/neutron_ovs_cleanup_marker/done`` to prevent
 further automatic executions until the host is rebooted. If the container
 configuration changes, the playbook recreates the container so the updated
 settings will be applied on the next run, but the container does not execute
-again while the marker file exists. Because ``/tmp`` is an ephemeral
-filesystem, the container recreates ``/tmp/kolla`` with mode ``1777``
-and copies the cleanup script to ``/tmp/kolla/neutron_ovs_cleanup``
-each time it starts so that the non-root ``neutron`` user can write to it.
-The marker path can be changed by overriding the variable
-``neutron_ovs_cleanup_marker_file``.
+again while the marker file exists. The container bind mounts the host
+``/tmp`` directory to preserve its contents between runs. Because ``/tmp`` is
+an ephemeral filesystem, the container recreates ``/tmp/kolla`` with mode
+``1777`` and copies the cleanup script to
+``/tmp/kolla/neutron_ovs_cleanup`` each time it starts so that the non-root
+``neutron`` user can write to it. The marker path can be changed by
+overriding the variable ``neutron_ovs_cleanup_marker_file``.
 
 The container executes the cleanup script as root directly, avoiding
 any reliance on ``sudo`` or interactive prompts.  It now explicitly

--- a/releasenotes/notes/ovs-cleanup-tmp-bind-mount-4f38f978b7ac4f1b.yaml
+++ b/releasenotes/notes/ovs-cleanup-tmp-bind-mount-4f38f978b7ac4f1b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Ensure the ``neutron_ovs_cleanup`` container bind mounts ``/tmp`` from
+    the host so that ``/tmp/kolla`` persists between runs and create the
+    directory when missing.


### PR DESCRIPTION
## Summary
- bind mount /tmp in neutron_ovs_cleanup container so /tmp/kolla persists
- document /tmp bind mount and directory creation

## Testing
- `tox -e linters` *(fails: jinja[invalid], var-naming, yaml, run-once)*

------
https://chatgpt.com/codex/tasks/task_e_689e0e2e38388327a14d588e022acc9e