### PR TITLE
Fix alias start order overrides

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -68,9 +68,6 @@
   loop: "{{ start_order_pairs }}"
   when: kolla_container_engine == 'podman'
   notify: Reload systemd
-  vars:
-    kolla_service_unit_prefix: "kolla-"
-    kolla_service_unit_suffix: "-container"
 
 - name: Reload systemd after applying overrides
   meta: flush_handlers

--- a/releasenotes/notes/fix-alias-start-order-delay-1daef8fe6a7f676a.yaml
+++ b/releasenotes/notes/fix-alias-start-order-delay-1daef8fe6a7f676a.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    When using Podman, systemd alias units (``kolla-<name>-container.service``)
+    now receive the same start-order drop-in as their corresponding
+    ``container-<name>.service`` units.  The drop-in ensures dependency
+    containers are healthy and honours any configured post-healthy delay during
+    boot, preventing services from starting simultaneously.
+...


### PR DESCRIPTION
## Summary
- ensure Podman alias units use same start-order drop-in
- document alias start-order fix

## Testing
- `ansible-lint ansible/roles/service-start-order/tasks/deploy.yml releasenotes/notes/fix-alias-start-order-delay-1daef8fe6a7f676a.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68a445d6a0588327adffa95676554563