### PR TITLE
Ensure service-start-order handles Podman alias units

### DIFF
--- a/ansible/roles/service-start-order/tasks/deploy.yml
+++ b/ansible/roles/service-start-order/tasks/deploy.yml
@@ -6,9 +6,20 @@
   loop: "{{ kolla_service_start_priority }}"
   register: service_units
 
+# Alias units (kolla-<name>-container.service) may be enabled instead of the
+# container-<name>.service units. Detect these so that start-order pairs are
+# built even when only alias units exist.
+- name: Detect services with alias systemd units
+  become: true
+  stat:
+    path: "/etc/systemd/system/kolla-{{ item }}-container.service"
+  loop: "{{ kolla_service_start_priority }}"
+  when: kolla_container_engine == 'podman'
+  register: alias_service_units
+
 - name: Build list of services with systemd units
   set_fact:
-    start_order_services: "{{ service_units.results | json_query('[?stat.exists].item') }}"
+    start_order_services: "{{ (service_units.results + (alias_service_units.results | default([]))) | json_query('[?stat.exists].item') | unique }}"
 
 - name: Build start order pairs
   set_fact:
@@ -65,6 +76,11 @@
     src: start-order.conf.j2
     dest: "/etc/systemd/system/kolla-{{ item.1 }}-container.service.d/start-order.conf"
     mode: "0644"
+  vars:
+    # Alias units use the traditional kolla-<name>-container.service naming for
+    # dependencies so override the prefix/suffix accordingly.
+    kolla_service_unit_prefix: "kolla-"
+    kolla_service_unit_suffix: "-container"
   loop: "{{ start_order_pairs }}"
   when: kolla_container_engine == 'podman'
   notify: Reload systemd

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -356,6 +356,10 @@ waiting for dependency health; ``0`` disables the timeout) and
 ``kolla_grace_no_healthcheck`` (seconds to pause when no health check exists).
 This delay applies even when a dependency reports healthy immediately
 and defaults to zero.
+When using Podman, the role inspects both ``container-<name>.service`` units
+and their ``kolla-<name>-container.service`` aliases, updating each with the
+necessary drop-ins so intra-project dependencies honour the configured
+post-healthy delay regardless of which unit is enabled.
 During deploy and reconfigure the role also verifies that
 each service reaches the ``running`` and ``healthy`` states before moving
 on to the next. Containers that are already healthy are left running unless

--- a/releasenotes/notes/service-start-order-alias-intra-project-8f5317a8e4bfa21f.yaml
+++ b/releasenotes/notes/service-start-order-alias-intra-project-8f5317a8e4bfa21f.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    When using Podman only the ``kolla-<name>-container.service`` alias units
+    might exist for some services. The ``service-start-order`` role now detects
+    these aliases and applies start-order drop-ins using the alias unit names,
+    ensuring that intra-project dependencies honour the configured post-healthy
+    delay during host boot.
+...


### PR DESCRIPTION
## Summary
- detect Podman alias units and include them when building service start-order
- generate start-order drop-ins for alias units using alias names
- document Podman alias unit handling

## Testing
- `tox -e linters` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a4536c3120832791225866bce438b2