### PR TITLE
fix(start-order): honour per-service post healthy delay

### DIFF
--- a/ansible/roles/nova-cell/defaults/main.yml
+++ b/ansible/roles/nova-cell/defaults/main.yml
@@ -394,6 +394,7 @@ nova_compute_healthcheck:
   start_period: "{{ nova_compute_healthcheck_start_period }}"
   test: "{% if nova_compute_enable_healthchecks | bool %}{{ nova_compute_healthcheck_test }}{% else %}NONE{% endif %}"
   timeout: "{{ nova_compute_healthcheck_timeout }}"
+nova_compute_post_healthy_delay: 30
 
 nova_compute_ironic_enable_healthchecks: "{{ enable_container_healthchecks }}"
 nova_compute_ironic_healthcheck_interval: "{{ default_container_healthcheck_interval }}"

--- a/ansible/roles/service-start-order/templates/start-order.conf.j2
+++ b/ansible/roles/service-start-order/templates/start-order.conf.j2
@@ -3,6 +3,6 @@ After={{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}
 Requires={{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}.service
 
 [Service]
-{% set post_delay = hostvars[inventory_hostname][item.1 ~ '_post_healthy_delay'] | default(kolla_post_healthy_delay) %}
+{% set post_delay = vars.get(item.1 ~ '_post_healthy_delay', kolla_post_healthy_delay) %}
 TimeoutStartSec={{ kolla_service_start_timeout }}
 ExecStartPre=/usr/local/lib/kolla/wait-unit-and-container-healthy.sh {{ kolla_service_unit_prefix }}{{ item.0 }}{{ kolla_service_unit_suffix }}.service {{ item.0 }} {{ post_delay }}

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -389,13 +389,14 @@ to them as well.
    kolla_service_healthcheck_retries: 60
    kolla_service_healthcheck_delay: 2
 
-For example ``nova_compute`` waits for ``nova_ssh`` to become healthy,
-``neutron_openvswitch_agent`` pauses for
+For example ``nova_compute`` waits for ``nova_ssh`` to become healthy and
+then delays an additional 30 seconds, controlled by
+``nova_compute_post_healthy_delay``. ``neutron_openvswitch_agent`` pauses for
 ``neutron_ovs_cleanup`` which lacks a health check, ``openvswitch_db``
 follows ``kolla_toolbox`` with the same delay, and ``openvswitch_vswitchd``
 waits for ``openvswitch_db`` to report healthy before delaying a further
-30 seconds. These defaults may be overridden in
-``/etc/kolla/globals.yml``.
+30 seconds via ``openvswitch_vswitchd_post_healthy_delay``. These defaults
+may be overridden in ``/etc/kolla/globals.yml``.
 
 The ``neutron_openvswitch_agent`` service waits for
 ``neutron_ovs_cleanup`` to complete before starting. The cleanup

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -36,9 +36,10 @@ for that check to succeed. The role installs a helper script at
 these checks. When no health indicator exists the delay is controlled by
 ``kolla_grace_no_healthcheck`` (default 30 seconds). An additional
 post-healthy delay may be configured via ``kolla_post_healthy_delay`` or
-per-service variables suffixed with ``_post_healthy_delay``. This delay
-applies even when a dependency reports healthy immediately and defaults to
-zero.
+per-service variables suffixed with ``_post_healthy_delay`` (for example,
+``openvswitch_vswitchd_post_healthy_delay`` or
+``nova_compute_post_healthy_delay``). This delay applies even when a
+dependency reports healthy immediately and defaults to zero.
 The role reloads systemd after writing any drop-in files so that new
 dependencies are applied immediately. It also stops containers that were
 previously launched directly via Podman and restarts them under systemd.


### PR DESCRIPTION
## Summary
- use per-service post healthy delay variables when rendering start-order drop-ins
- set nova_compute_post_healthy_delay default to 30s
- document per-service post-healthy delays

## Testing
- `tox -e linters` *(fails: 26 rule violations from ansible-lint)*
- `.tox/linters/bin/ansible-lint ansible/roles/service-start-order/templates/start-order.conf.j2 ansible/roles/nova-cell/defaults/main.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a463d0ec508327b547586db0fa04f1