### PR TITLE
Increase post-healthy delay default to 30s

### DIFF
--- a/ansible/roles/service-start-order/defaults/main.yml
+++ b/ansible/roles/service-start-order/defaults/main.yml
@@ -28,7 +28,7 @@ kolla_service_start_timeout: 0
 # Delay applied when a dependency has no container healthcheck.
 kolla_grace_no_healthcheck: 30
 # Delay applied after a dependency becomes healthy.
-kolla_post_healthy_delay: 0
+kolla_post_healthy_delay: 30
 # Attempts and delay for verifying container health after restart/start
 kolla_service_healthcheck_retries: 60
 kolla_service_healthcheck_delay: 2

--- a/ansible/roles/service-start-order/templates/wait-unit-and-container-healthy.sh.j2
+++ b/ansible/roles/service-start-order/templates/wait-unit-and-container-healthy.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/sh
 unit="$1"
 container="$2"
-post_delay="${3:-0}"
+post_delay="${3:-{{ kolla_post_healthy_delay }}}"
 
 until systemctl is-active --quiet "$unit"; do
     sleep 1

--- a/doc/source/admin/advanced-configuration.rst
+++ b/doc/source/admin/advanced-configuration.rst
@@ -352,10 +352,11 @@ applied before continuing. The role installs a helper script at
 these checks and avoid brittle inline shell in the systemd drop-in. The
 delays are controlled by the variables
 ``kolla_service_start_timeout`` (systemd ``TimeoutStartSec`` applied while
-waiting for dependency health; ``0`` disables the timeout) and
-``kolla_grace_no_healthcheck`` (seconds to pause when no health check exists).
-This delay applies even when a dependency reports healthy immediately
-and defaults to zero.
+waiting for dependency health; ``0`` disables the timeout),
+``kolla_grace_no_healthcheck`` (seconds to pause when no health check exists),
+and ``kolla_post_healthy_delay`` (seconds to pause after a dependency reports
+healthy). This delay applies even when a dependency reports healthy immediately
+and defaults to 30 seconds.
 When using Podman, the role inspects both ``container-<name>.service`` units
 and their ``kolla-<name>-container.service`` aliases, updating each with the
 necessary drop-ins so intra-project dependencies honour the configured
@@ -385,7 +386,7 @@ to them as well.
 
    kolla_service_start_timeout: 0
    kolla_grace_no_healthcheck: 30
-   kolla_post_healthy_delay: 0
+   kolla_post_healthy_delay: 30
    kolla_service_healthcheck_retries: 60
    kolla_service_healthcheck_delay: 2
 

--- a/doc/source/admin/podman.rst
+++ b/doc/source/admin/podman.rst
@@ -39,7 +39,7 @@ post-healthy delay may be configured via ``kolla_post_healthy_delay`` or
 per-service variables suffixed with ``_post_healthy_delay`` (for example,
 ``openvswitch_vswitchd_post_healthy_delay`` or
 ``nova_compute_post_healthy_delay``). This delay applies even when a
-dependency reports healthy immediately and defaults to zero.
+dependency reports healthy immediately and defaults to 30 seconds.
 The role reloads systemd after writing any drop-in files so that new
 dependencies are applied immediately. It also stops containers that were
 previously launched directly via Podman and restarts them under systemd.

--- a/releasenotes/notes/post-healthy-delay-default-30-sec.yaml
+++ b/releasenotes/notes/post-healthy-delay-default-30-sec.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The default ``kolla_post_healthy_delay`` has been increased from ``0`` to
+    ``30`` seconds, causing services to wait an additional 30 seconds after
+    dependencies report healthy before starting.


### PR DESCRIPTION
## Summary
- default services to wait 30s after dependencies report healthy
- document new post-healthy delay behaviour

## Testing
- `tox -e linters` *(fails: 26 fatal violations)*
- `tox -e docs`


------
https://chatgpt.com/codex/tasks/task_e_68a4807aaf508327913e2d3bc25b9c01