### PR TITLE
Fix neutron-ovs-cleanup container needlessly recreated on every run

### DIFF
--- a/ansible/module_utils/kolla_container_worker.py
+++ b/ansible/module_utils/kolla_container_worker.py
@@ -899,6 +899,13 @@ class ContainerWorker(ABC):
         # container recreation during deploys and reconfigures.
         if new_state == "exited" and current_state in ("configured", "created"):
             return False
+        # When start is False, the caller only wants the container to exist
+        # (not necessarily running).  Accept any non-removed state as
+        # matching so we don't needlessly recreate containers like
+        # neutron-ovs-cleanup that are created with start=false.
+        if not self.params.get("start", True):
+            if current_state in ("configured", "created", "exited", "stopped"):
+                return False
         if new_state != current_state:
             return True
 


### PR DESCRIPTION
compare_container_state() always found a diff for containers created with start=false (like neutron-ovs-cleanup): new_state was None while current_state was "configured", so the container was stopped, removed, and recreated every deploy — which is slow and unnecessary.

When start=false, accept any non-removed state (configured, created, exited, stopped) as matching since the caller only wants the container to exist, not to be running.

https://claude.ai/code/session_015RmWWLygnCCLw8aAtk45Qb